### PR TITLE
Add initial API with health endpoint

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/?(*.)+(spec|test).[tj]s?(x)'],
+};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "> **Disclaimer:**\r >\r > This project is being developed to support Boys State & Girls State programs affiliated with the American Legion, but is **not** created, funded, or officially supported by the American Legion. No endorsement or sponsorship is implied. All branding, configuration, and operational decisions are made independently by the app’s creators and participating programs.",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "jest",
     "dev": "ts-node src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js",
@@ -18,13 +18,20 @@
     "@prisma/client": "^6.10.1",
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",
-    "express": "^5.1.0"
+    "express": "^5.1.0",
+    "swagger-ui-express": "^5.0.0",
+    "yaml": "^2.4.2"
   },
   "devDependencies": {
     "@types/express": "^5.0.3",
     "@types/node": "^24.0.3",
     "prisma": "^6.10.1",
     "ts-node": "^10.9.2",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "ts-jest": "^29.0.5",
+    "jest": "^29.7.0",
+    "@types/jest": "^29.5.5",
+    "supertest": "^6.3.4",
+    "@types/supertest": "^2.0.12"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,25 @@
+import express from 'express';
+import cors from 'cors';
+import { readFileSync } from 'fs';
+import path from 'path';
+import swaggerUi from 'swagger-ui-express';
+import yaml from 'yaml';
+
+const app = express();
+app.use(cors());
+
+// Load OpenAPI spec
+const openApiPath = path.join(__dirname, 'openapi.yaml');
+const openApiDoc = yaml.parse(readFileSync(openApiPath, 'utf8'));
+app.use('/docs', swaggerUi.serve, swaggerUi.setup(openApiDoc));
+
+app.get('/health', (_req, res) => {
+  res.json({ status: 'ok' });
+});
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => {
+  console.log(`Server listening on port ${port}`);
+});
+
+export default app;

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -1,0 +1,24 @@
+openapi: 3.0.0
+info:
+  title: Boys State App API
+  description: |
+    **Disclaimer:** This project is being developed to support Boys State & Girls State programs affiliated with the American Legion, but is not created, funded, or officially supported by the American Legion. No endorsement or sponsorship is implied. All branding, configuration, and operational decisions are made independently by the app’s creators and participating programs.
+  version: 1.0.0
+servers:
+  - url: http://localhost:3000
+paths:
+  /health:
+    get:
+      summary: Health check endpoint
+      description: Returns a simple status to verify the API is running.
+      responses:
+        '200':
+          description: Successful health response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: ok

--- a/test/health.test.ts
+++ b/test/health.test.ts
@@ -1,0 +1,10 @@
+import request from 'supertest';
+import app from '../src/index';
+
+describe('GET /health', () => {
+  it('returns status ok', async () => {
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'ok' });
+  });
+});


### PR DESCRIPTION
## Summary
- implement Express server
- add `/health` route
- expose OpenAPI spec and Swagger UI
- configure Jest and add a basic health check test
- update project dependencies

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6857fee7d2c4832dbf3779ad40f93d26