### PR TITLE
Fix Prisma client setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,16 +28,21 @@ This repository contains the **backend REST API and core services** for Boys Sta
    npm install
    # or pip install -r requirements.txt
    ```
-2. **Set up environment variables:**
+2. **Generate Prisma client:**
+
+   ```bash
+   npm run prisma:generate
+   ```
+3. **Set up environment variables:**
 
    * Copy `.env.example` to `.env` and configure database, API, and auth credentials.
-3. **Run the service:**
+4. **Run the service:**
 
    ```bash
    npm run start
    # or python app.py / your start command
    ```
-4. **API documentation:**
+5. **API documentation:**
 
    * Access Swagger/OpenAPI docs at `/docs` or as configured.
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -6,7 +6,6 @@
 
 generator client {
   provider = "prisma-client-js"
-  output   = "../generated/prisma"
 }
 
 datasource db {


### PR DESCRIPTION
## Summary
- remove custom Prisma client output so `@prisma/client` loads correctly
- document that `npm run prisma:generate` should be run after installing dependencies

## Testing
- `npx prisma generate`
- `npm run build`
- `npx jest --runInBand`

------
https://chatgpt.com/codex/tasks/task_b_685818fe3aac832dbfdeff5aeb0ea26a