### PR TITLE
Add basic user registration and login

### DIFF
--- a/dist/__mocks__/prisma.js
+++ b/dist/__mocks__/prisma.js
@@ -2,5 +2,9 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 const prisma = {
     $queryRaw: jest.fn(),
+    user: {
+        create: jest.fn(),
+        findUnique: jest.fn(),
+    },
 };
 exports.default = prisma;

--- a/dist/index.js
+++ b/dist/index.js
@@ -9,13 +9,18 @@ const fs_1 = require("fs");
 const path_1 = __importDefault(require("path"));
 const swagger_ui_express_1 = __importDefault(require("swagger-ui-express"));
 const yaml_1 = __importDefault(require("yaml"));
+const crypto_1 = __importDefault(require("crypto"));
 const prisma_1 = __importDefault(require("./prisma"));
 const app = (0, express_1.default)();
 app.use((0, cors_1.default)());
+app.use(express_1.default.json());
 // Load OpenAPI spec
 const openApiPath = path_1.default.join(__dirname, 'openapi.yaml');
 const openApiDoc = yaml_1.default.parse((0, fs_1.readFileSync)(openApiPath, 'utf8'));
 app.use('/docs', swagger_ui_express_1.default.serve, swagger_ui_express_1.default.setup(openApiDoc));
+function hashPassword(password) {
+    return crypto_1.default.createHash('sha256').update(password).digest('hex');
+}
 app.get('/health', async (_req, res) => {
     console.log('Serving /health');
     let dbStatus = 'ok';
@@ -27,6 +32,40 @@ app.get('/health', async (_req, res) => {
         dbStatus = 'error';
     }
     res.json({ status: 'ok', database: dbStatus });
+});
+app.post('/register', async (req, res) => {
+    const { email, password } = req.body;
+    if (!email || !password) {
+        res.status(400).json({ error: 'Missing fields' });
+        return;
+    }
+    const passwordHash = hashPassword(password);
+    try {
+        const user = await prisma_1.default.user.create({ data: { email, passwordHash } });
+        res.status(201).json({ id: user.id, email: user.email });
+    }
+    catch (err) {
+        console.error('Registration failed', err);
+        res.status(400).json({ error: 'Registration failed' });
+    }
+});
+app.post('/login', async (req, res) => {
+    const { email, password } = req.body;
+    if (!email || !password) {
+        res.status(400).json({ error: 'Missing fields' });
+        return;
+    }
+    const user = await prisma_1.default.user.findUnique({ where: { email } });
+    if (!user) {
+        res.status(401).json({ error: 'Invalid credentials' });
+        return;
+    }
+    const passwordHash = hashPassword(password);
+    if (passwordHash !== user.passwordHash) {
+        res.status(401).json({ error: 'Invalid credentials' });
+        return;
+    }
+    res.json({ id: user.id, email: user.email });
 });
 const port = process.env.PORT || 3000;
 app.listen(port, () => {

--- a/dist/openapi.yaml
+++ b/dist/openapi.yaml
@@ -25,3 +25,47 @@ paths:
                   database:
                     type: string
                     example: ok
+  /register:
+    post:
+      summary: Register a new user account
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - email
+                - password
+              properties:
+                email:
+                  type: string
+                password:
+                  type: string
+      responses:
+        '201':
+          description: User created
+        '400':
+          description: Registration failed
+  /login:
+    post:
+      summary: Login with an existing account
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - email
+                - password
+              properties:
+                email:
+                  type: string
+                password:
+                  type: string
+      responses:
+        '200':
+          description: Successful login
+        '401':
+          description: Invalid credentials

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,3 +12,10 @@ datasource db {
   provider = "postgresql"
   url      = env("DATABASE_URL")
 }
+
+model User {
+  id           Int      @id @default(autoincrement())
+  email        String   @unique
+  passwordHash String
+  createdAt    DateTime @default(now())
+}

--- a/src/__mocks__/prisma.ts
+++ b/src/__mocks__/prisma.ts
@@ -1,5 +1,9 @@
 const prisma = {
   $queryRaw: jest.fn(),
+  user: {
+    create: jest.fn(),
+    findUnique: jest.fn(),
+  },
 };
 
 export default prisma;

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,15 +4,21 @@ import { readFileSync } from 'fs';
 import path from 'path';
 import swaggerUi from 'swagger-ui-express';
 import yaml from 'yaml';
+import crypto from 'crypto';
 import prisma from './prisma';
 
 const app = express();
 app.use(cors());
+app.use(express.json());
 
 // Load OpenAPI spec
 const openApiPath = path.join(__dirname, 'openapi.yaml');
 const openApiDoc = yaml.parse(readFileSync(openApiPath, 'utf8'));
 app.use('/docs', swaggerUi.serve, swaggerUi.setup(openApiDoc));
+
+function hashPassword(password: string): string {
+  return crypto.createHash('sha256').update(password).digest('hex');
+}
 
 app.get('/health', async (_req, res) => {
   console.log('Serving /health');
@@ -24,6 +30,41 @@ app.get('/health', async (_req, res) => {
     dbStatus = 'error';
   }
   res.json({ status: 'ok', database: dbStatus });
+});
+
+app.post('/register', async (req, res) => {
+  const { email, password } = req.body as { email?: string; password?: string };
+  if (!email || !password) {
+    res.status(400).json({ error: 'Missing fields' });
+    return;
+  }
+  const passwordHash = hashPassword(password);
+  try {
+    const user = await prisma.user.create({ data: { email, passwordHash } });
+    res.status(201).json({ id: user.id, email: user.email });
+  } catch (err) {
+    console.error('Registration failed', err);
+    res.status(400).json({ error: 'Registration failed' });
+  }
+});
+
+app.post('/login', async (req, res) => {
+  const { email, password } = req.body as { email?: string; password?: string };
+  if (!email || !password) {
+    res.status(400).json({ error: 'Missing fields' });
+    return;
+  }
+  const user = await prisma.user.findUnique({ where: { email } });
+  if (!user) {
+    res.status(401).json({ error: 'Invalid credentials' });
+    return;
+  }
+  const passwordHash = hashPassword(password);
+  if (passwordHash !== user.passwordHash) {
+    res.status(401).json({ error: 'Invalid credentials' });
+    return;
+  }
+  res.json({ id: user.id, email: user.email });
 });
 
 const port = process.env.PORT || 3000;

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -25,3 +25,47 @@ paths:
                   database:
                     type: string
                     example: ok
+  /register:
+    post:
+      summary: Register a new user account
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - email
+                - password
+              properties:
+                email:
+                  type: string
+                password:
+                  type: string
+      responses:
+        '201':
+          description: User created
+        '400':
+          description: Registration failed
+  /login:
+    post:
+      summary: Login with an existing account
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - email
+                - password
+              properties:
+                email:
+                  type: string
+                password:
+                  type: string
+      responses:
+        '200':
+          description: Successful login
+        '401':
+          description: Invalid credentials

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -1,0 +1,33 @@
+import request from 'supertest';
+import crypto from 'crypto';
+jest.mock('../src/prisma');
+import prisma from '../src/prisma';
+import app from '../src/index';
+
+const mockedPrisma = prisma as any;
+
+function sha(password: string) {
+  return crypto.createHash('sha256').update(password).digest('hex');
+}
+
+describe('Auth endpoints', () => {
+  beforeEach(() => {
+    mockedPrisma.user.create.mockReset();
+    mockedPrisma.user.findUnique.mockReset();
+  });
+
+  it('registers a user', async () => {
+    mockedPrisma.user.create.mockResolvedValueOnce({ id: 1, email: 'a@b.c', passwordHash: sha('pass') } as any);
+    const res = await request(app).post('/register').send({ email: 'a@b.c', password: 'pass' });
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual({ id: 1, email: 'a@b.c' });
+    expect(mockedPrisma.user.create).toHaveBeenCalledWith({ data: { email: 'a@b.c', passwordHash: sha('pass') } });
+  });
+
+  it('rejects invalid login', async () => {
+    mockedPrisma.user.findUnique.mockResolvedValueOnce({ id: 1, email: 'a@b.c', passwordHash: sha('pass') } as any);
+    const res = await request(app).post('/login').send({ email: 'a@b.c', password: 'wrong' });
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ error: 'Invalid credentials' });
+  });
+});


### PR DESCRIPTION
## Summary
- add User model to Prisma schema
- create `/register` and `/login` API endpoints
- document new endpoints in OpenAPI spec
- mock Prisma user operations for tests
- add auth endpoint tests
- rebuild dist after tests

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6858c7365958832dbc5f545aa8208593