### PR TITLE
Add basic user auth endpoints

### DIFF
--- a/dist/__mocks__/prisma.js
+++ b/dist/__mocks__/prisma.js
@@ -2,5 +2,9 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 const prisma = {
     $queryRaw: jest.fn(),
+    user: {
+        findUnique: jest.fn(),
+        create: jest.fn(),
+    },
 };
 exports.default = prisma;

--- a/dist/openapi.yaml
+++ b/dist/openapi.yaml
@@ -25,3 +25,49 @@ paths:
                   database:
                     type: string
                     example: ok
+  /register:
+    post:
+      summary: Create a new user
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - email
+                - password
+              properties:
+                email:
+                  type: string
+                password:
+                  type: string
+      responses:
+        '201':
+          description: User created
+        '400':
+          description: Email already exists or invalid input
+  /login:
+    post:
+      summary: Log in with existing credentials
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - email
+                - password
+              properties:
+                email:
+                  type: string
+                password:
+                  type: string
+      responses:
+        '200':
+          description: Login successful
+        '400':
+          description: Missing credentials
+        '401':
+          description: Invalid credentials

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,4 +2,5 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   testMatch: ['**/?(*.)+(spec|test).[tj]s?(x)'],
+  modulePathIgnorePatterns: ['<rootDir>/dist/'],
 };

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,3 +12,10 @@ datasource db {
   provider = "postgresql"
   url      = env("DATABASE_URL")
 }
+
+model User {
+  id        Int      @id @default(autoincrement())
+  email     String   @unique
+  password  String
+  createdAt DateTime @default(now())
+}

--- a/src/__mocks__/prisma.ts
+++ b/src/__mocks__/prisma.ts
@@ -1,5 +1,9 @@
 const prisma = {
   $queryRaw: jest.fn(),
+  user: {
+    findUnique: jest.fn(),
+    create: jest.fn(),
+  },
 };
 
 export default prisma;

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,15 +4,66 @@ import { readFileSync } from 'fs';
 import path from 'path';
 import swaggerUi from 'swagger-ui-express';
 import yaml from 'yaml';
+import { randomBytes, scrypt as _scrypt } from 'crypto';
+import { promisify } from 'util';
 import prisma from './prisma';
+
+const scrypt = promisify(_scrypt);
 
 const app = express();
 app.use(cors());
+app.use(express.json());
 
 // Load OpenAPI spec
 const openApiPath = path.join(__dirname, 'openapi.yaml');
 const openApiDoc = yaml.parse(readFileSync(openApiPath, 'utf8'));
 app.use('/docs', swaggerUi.serve, swaggerUi.setup(openApiDoc));
+
+app.post('/register', async (req: express.Request, res: express.Response) => {
+  const { email, password } = req.body as { email?: string; password?: string };
+  if (!email || !password) {
+    res.status(400).json({ error: 'Email and password required' });
+    return;
+  }
+
+  const existing = await prisma.user.findUnique({ where: { email } });
+  if (existing) {
+    res.status(400).json({ error: 'User already exists' });
+    return;
+  }
+
+  const salt = randomBytes(16).toString('hex');
+  const buf = (await scrypt(password, salt, 64)) as Buffer;
+  const hashed = `${salt}:${buf.toString('hex')}`;
+
+  await prisma.user.create({ data: { email, password: hashed } });
+  res.status(201).json({ message: 'User created' });
+  return;
+});
+
+app.post('/login', async (req: express.Request, res: express.Response) => {
+  const { email, password } = req.body as { email?: string; password?: string };
+  if (!email || !password) {
+    res.status(400).json({ error: 'Email and password required' });
+    return;
+  }
+
+  const user = await prisma.user.findUnique({ where: { email } });
+  if (!user) {
+    res.status(401).json({ error: 'Invalid credentials' });
+    return;
+  }
+
+  const [salt, storedHash] = user.password.split(':');
+  const buf = (await scrypt(password, salt, 64)) as Buffer;
+  if (buf.toString('hex') !== storedHash) {
+    res.status(401).json({ error: 'Invalid credentials' });
+    return;
+  }
+
+  res.json({ message: 'Logged in' });
+  return;
+});
 
 app.get('/health', async (_req, res) => {
   console.log('Serving /health');
@@ -27,8 +78,10 @@ app.get('/health', async (_req, res) => {
 });
 
 const port = process.env.PORT || 3000;
-app.listen(port, () => {
-  console.log(`Server listening on port ${port}`);
-});
+if (process.env.NODE_ENV !== 'test') {
+  app.listen(port, () => {
+    console.log(`Server listening on port ${port}`);
+  });
+}
 
 export default app;

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -25,3 +25,49 @@ paths:
                   database:
                     type: string
                     example: ok
+  /register:
+    post:
+      summary: Create a new user
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - email
+                - password
+              properties:
+                email:
+                  type: string
+                password:
+                  type: string
+      responses:
+        '201':
+          description: User created
+        '400':
+          description: Email already exists or invalid input
+  /login:
+    post:
+      summary: Log in with existing credentials
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - email
+                - password
+              properties:
+                email:
+                  type: string
+                password:
+                  type: string
+      responses:
+        '200':
+          description: Login successful
+        '400':
+          description: Missing credentials
+        '401':
+          description: Invalid credentials

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -1,0 +1,57 @@
+import request from 'supertest';
+jest.mock('../src/prisma');
+import prisma from '../src/prisma';
+import app from '../src/index';
+
+const mockedPrisma = prisma as any;
+
+describe('Auth endpoints', () => {
+  beforeEach(() => {
+    mockedPrisma.user.findUnique.mockReset();
+    mockedPrisma.user.create.mockReset();
+    jest.restoreAllMocks();
+  });
+
+  describe('POST /register', () => {
+    it('creates a new user', async () => {
+      mockedPrisma.user.findUnique.mockResolvedValueOnce(null as any);
+      mockedPrisma.user.create.mockResolvedValueOnce({ id: 1 } as any);
+      const res = await request(app)
+        .post('/register')
+        .send({ email: 'test@example.com', password: 'secret' });
+      expect(res.status).toBe(201);
+      expect(res.body).toEqual({ message: 'User created' });
+      expect(mockedPrisma.user.create).toHaveBeenCalled();
+    });
+
+    it('fails when user exists', async () => {
+      mockedPrisma.user.findUnique.mockResolvedValueOnce({ id: 1 } as any);
+      const res = await request(app)
+        .post('/register')
+        .send({ email: 'test@example.com', password: 'secret' });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('POST /login', () => {
+    it('logs in with correct credentials', async () => {
+      const hash = '05ffaebcca41770af425d4ba9b4e7bcdff532237dca931c192a36d94db7307d4c2df95e606514b4113ccb3ad3c19f7ca648e373a112a6b8290f3a69818aa9b7e';
+      const passwordHash = `salt:${hash}`;
+      mockedPrisma.user.findUnique.mockResolvedValueOnce({ id: 1, email: 'test@example.com', password: passwordHash } as any);
+
+      const res = await request(app)
+        .post('/login')
+        .send({ email: 'test@example.com', password: 'secret' });
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ message: 'Logged in' });
+    });
+
+    it('fails with invalid credentials', async () => {
+      mockedPrisma.user.findUnique.mockResolvedValueOnce(null as any);
+      const res = await request(app)
+        .post('/login')
+        .send({ email: 'bad@example.com', password: 'nope' });
+      expect(res.status).toBe(401);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- create a `User` model for Prisma
- add registration and login endpoints using scrypt password hashing
- document the new endpoints in OpenAPI spec
- update Jest config and mock Prisma client for tests
- test auth flows

## Testing
- `npx jest --runInBand`
- `npm run build --silent`

------
https://chatgpt.com/codex/tasks/task_b_6861cb910630832d8864df825de94f97