### PR TITLE
Fix prisma client not generated before tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "> **Disclaimer:**\r >\r > This project is being developed to support Boys State & Girls State programs affiliated with the American Legion, but is **not** created, funded, or officially supported by the American Legion. No endorsement or sponsorship is implied. All branding, configuration, and operational decisions are made independently by the app’s creators and participating programs.",
   "main": "index.js",
   "scripts": {
+    "pretest": "npm run prisma:generate",
     "test": "jest",
     "dev": "ts-node src/index.ts",
     "build": "tsc && cp src/openapi.yaml dist/openapi.yaml",


### PR DESCRIPTION
## Summary
- ensure Prisma client is generated before running tests

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6861dadf357c832daabbe113cfbde3ac