### PR TITLE
Add JWT expiration

### DIFF
--- a/dist/openapi.yaml
+++ b/dist/openapi.yaml
@@ -124,7 +124,7 @@ paths:
                 properties:
                   token:
                     type: string
-                    description: JWT authentication token
+                    description: JWT authentication token (expires after 30 minutes)
                     example: >-
                       eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjEsImlhdCI6MT
                       Y4NTg0OTc1NX0.LXrlo3wrX7rQiGZnYuxRKgXUxRvQPgFP5yxv1rdqe8E

--- a/src/jwt.ts
+++ b/src/jwt.ts
@@ -8,9 +8,16 @@ function base64url(input: Buffer | string): string {
     .replace(/=+$/, '');
 }
 
-export function sign(payload: object, secret: string): string {
+export function sign(
+  payload: object,
+  secret: string,
+  expiresInSec = 30 * 60
+): string {
+  const iat = Math.floor(Date.now() / 1000);
+  const exp = iat + expiresInSec;
+  const fullPayload = { ...payload, iat, exp };
   const header = base64url(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
-  const body = base64url(JSON.stringify(payload));
+  const body = base64url(JSON.stringify(fullPayload));
   const signature = createHmac('sha256', secret)
     .update(`${header}.${body}`)
     .digest('base64');
@@ -32,5 +39,12 @@ export function verify(token: string, secret: string): any {
     payloadB64.replace(/-/g, '+').replace(/_/g, '/'),
     'base64'
   ).toString('utf8');
-  return JSON.parse(payloadJson);
+  const payload = JSON.parse(payloadJson);
+  if (
+    payload.exp !== undefined &&
+    Math.floor(Date.now() / 1000) >= payload.exp
+  ) {
+    throw new Error('Token expired');
+  }
+  return payload;
 }

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -124,7 +124,7 @@ paths:
                 properties:
                   token:
                     type: string
-                    description: JWT authentication token
+                    description: JWT authentication token (expires after 30 minutes)
                     example: >-
                       eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjEsImlhdCI6MT
                       Y4NTg0OTc1NX0.LXrlo3wrX7rQiGZnYuxRKgXUxRvQPgFP5yxv1rdqe8E


### PR DESCRIPTION
## Summary
- add default 30 minute expiration to JWT tokens
- validate expiration on verify
- update login tests for new payload
- add test for expired token case
- document token expiry in OpenAPI
- rebuild dist

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6863c52b597c832da880d7b9ba2d31b5