### PR TITLE
Add programs endpoint

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -101,6 +101,20 @@ app.get('/health', async (_req, res) => {
     }
     res.json({ status: 'ok', database: dbStatus });
 });
+app.get('/programs', async (req, res) => {
+    const userId = req.user.userId;
+    const user = await prisma_1.default.user.findUnique({ where: { id: userId } });
+    const assignments = await prisma_1.default.programAssignment.findMany({
+        where: { userId },
+        include: { program: true },
+    });
+    const programs = assignments.map((a) => ({
+        programId: a.program.id,
+        programName: a.program.name,
+        role: a.role,
+    }));
+    res.json({ username: user?.email ?? '', programs });
+});
 const port = process.env.PORT || 3000;
 if (process.env.NODE_ENV !== 'test') {
     ensureDatabase();

--- a/dist/openapi.yaml
+++ b/dist/openapi.yaml
@@ -148,6 +148,41 @@ paths:
                   error:
                     type: string
                     example: Invalid credentials
+  /programs:
+    get:
+      tags: [programs]
+      summary: List programs for user
+      description: >
+        Returns all programs assigned to the authenticated user. Each item
+        includes the program id, name, and role.
+      responses:
+        '200':
+          description: List of programs
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  username:
+                    type: string
+                    description: User email or username
+                    example: jane.doe
+                  programs:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        programId:
+                          type: string
+                          example: abc123
+                        programName:
+                          type: string
+                          example: Boys State Texas
+                        role:
+                          type: string
+                          example: admin
+      security:
+        - bearerAuth: []
 components:
   securitySchemes:
     bearerAuth:

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,4 +18,25 @@ model User {
   email     String   @unique
   password  String
   createdAt DateTime @default(now())
+  programs  ProgramAssignment[]
+  createdPrograms Program[] @relation("ProgramCreatedBy")
+}
+
+model Program {
+  id          String             @id @default(cuid())
+  name        String
+  createdBy   User               @relation("ProgramCreatedBy", fields: [createdById], references: [id])
+  createdById Int
+  assignments ProgramAssignment[]
+  createdAt   DateTime           @default(now())
+}
+
+model ProgramAssignment {
+  id        Int      @id @default(autoincrement())
+  user      User     @relation(fields: [userId], references: [id])
+  userId    Int
+  program   Program  @relation(fields: [programId], references: [id])
+  programId String
+  role      String
+  createdAt DateTime @default(now())
 }

--- a/src/__mocks__/prisma.ts
+++ b/src/__mocks__/prisma.ts
@@ -4,6 +4,9 @@ const prisma = {
     findUnique: jest.fn(),
     create: jest.fn(),
   },
+  programAssignment: {
+    findMany: jest.fn(),
+  },
 };
 
 export default prisma;

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,6 +109,21 @@ app.get('/health', async (_req, res) => {
   res.json({ status: 'ok', database: dbStatus });
 });
 
+app.get('/programs', async (req, res) => {
+  const userId = (req as any).user.userId as number;
+  const user = await prisma.user.findUnique({ where: { id: userId } });
+  const assignments = await prisma.programAssignment.findMany({
+    where: { userId },
+    include: { program: true },
+  });
+  const programs = assignments.map((a: any) => ({
+    programId: a.program.id,
+    programName: a.program.name,
+    role: a.role,
+  }));
+  res.json({ username: user?.email ?? '', programs });
+});
+
 const port = process.env.PORT || 3000;
 if (process.env.NODE_ENV !== 'test') {
   ensureDatabase();

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -148,6 +148,41 @@ paths:
                   error:
                     type: string
                     example: Invalid credentials
+  /programs:
+    get:
+      tags: [programs]
+      summary: List programs for user
+      description: >
+        Returns all programs assigned to the authenticated user. Each item
+        includes the program id, name, and role.
+      responses:
+        '200':
+          description: List of programs
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  username:
+                    type: string
+                    description: User email or username
+                    example: jane.doe
+                  programs:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        programId:
+                          type: string
+                          example: abc123
+                        programName:
+                          type: string
+                          example: Boys State Texas
+                        role:
+                          type: string
+                          example: admin
+      security:
+        - bearerAuth: []
 components:
   securitySchemes:
     bearerAuth:

--- a/test/programs.test.ts
+++ b/test/programs.test.ts
@@ -1,0 +1,45 @@
+import request from 'supertest';
+jest.mock('../src/prisma');
+import prisma from '../src/prisma';
+import app from '../src/index';
+import { sign } from '../src/jwt';
+
+const mockedPrisma = prisma as any;
+
+describe('GET /programs', () => {
+  beforeEach(() => {
+    mockedPrisma.programAssignment.findMany.mockReset();
+    mockedPrisma.user.findUnique.mockReset();
+  });
+
+  it('returns programs for the user', async () => {
+    mockedPrisma.user.findUnique.mockResolvedValueOnce({ id: 1, email: 'jane.doe' });
+    mockedPrisma.programAssignment.findMany.mockResolvedValueOnce([
+      { role: 'admin', program: { id: 'abc123', name: 'Boys State Texas' } },
+      { role: 'counselor', program: { id: 'def456', name: 'Girls State Florida' } },
+    ]);
+    const token = sign({ userId: 1 }, 'development-secret');
+    const res = await request(app)
+      .get('/programs')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      username: 'jane.doe',
+      programs: [
+        { programId: 'abc123', programName: 'Boys State Texas', role: 'admin' },
+        { programId: 'def456', programName: 'Girls State Florida', role: 'counselor' },
+      ],
+    });
+  });
+
+  it('returns empty array when user has no programs', async () => {
+    mockedPrisma.user.findUnique.mockResolvedValueOnce({ id: 2, email: 'jane.doe' });
+    mockedPrisma.programAssignment.findMany.mockResolvedValueOnce([]);
+    const token = sign({ userId: 2 }, 'development-secret');
+    const res = await request(app)
+      .get('/programs')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ username: 'jane.doe', programs: [] });
+  });
+});


### PR DESCRIPTION
## Summary
- add Program and ProgramAssignment models
- implement `/programs` endpoint
- document `/programs` in OpenAPI spec
- mock programAssignment in tests
- test listing programs for a user
- rebuild dist

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6863cf61d1e4832daa0421bdf8db79f5