### PR TITLE
Make Swagger docs public

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -20,7 +20,9 @@ app.use((0, cors_1.default)());
 app.use(express_1.default.json());
 const jwtSecret = process.env.JWT_SECRET || 'development-secret';
 app.use((req, res, next) => {
-    if (req.path === '/login' || req.path === '/register') {
+    if (req.path === '/login' ||
+        req.path === '/register' ||
+        req.path.startsWith('/docs')) {
         return next();
     }
     const auth = req.headers.authorization;

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,11 @@ app.use(express.json());
 const jwtSecret = process.env.JWT_SECRET || 'development-secret';
 
 app.use((req, res, next) => {
-  if (req.path === '/login' || req.path === '/register') {
+  if (
+    req.path === '/login' ||
+    req.path === '/register' ||
+    req.path.startsWith('/docs')
+  ) {
     return next();
   }
   const auth = req.headers.authorization;

--- a/test/docs.test.ts
+++ b/test/docs.test.ts
@@ -1,0 +1,10 @@
+import request from 'supertest';
+jest.mock('../src/prisma');
+import app from '../src/index';
+
+describe('GET /docs', () => {
+  it('is accessible without authentication', async () => {
+    const res = await request(app).get('/docs');
+    expect(res.status).not.toBe(401);
+  });
+});


### PR DESCRIPTION
## Summary
- allow unauthenticated access to `/docs`
- test swagger accessibility
- rebuild dist folder

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6863da51b498832d80a4f322bbd80ab6