### PR TITLE
Include email in JWT token

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -87,7 +87,7 @@ app.post('/login', async (req, res) => {
         res.status(401).json({ error: 'Invalid credentials' });
         return;
     }
-    const token = (0, jwt_1.sign)({ userId: user.id }, jwtSecret);
+    const token = (0, jwt_1.sign)({ userId: user.id, email: user.email }, jwtSecret);
     res.json({ token });
     return;
 });

--- a/dist/openapi.yaml
+++ b/dist/openapi.yaml
@@ -124,7 +124,7 @@ paths:
                 properties:
                   token:
                     type: string
-                    description: JWT authentication token (expires after 30 minutes)
+                    description: JWT authentication token containing user id and email (expires after 30 minutes)
                     example: >-
                       eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjEsImlhdCI6MT
                       Y4NTg0OTc1NX0.LXrlo3wrX7rQiGZnYuxRKgXUxRvQPgFP5yxv1rdqe8E

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,7 +96,7 @@ app.post('/login', async (req: express.Request, res: express.Response) => {
     return;
   }
 
-  const token = sign({ userId: user.id }, jwtSecret);
+  const token = sign({ userId: user.id, email: user.email }, jwtSecret);
   res.json({ token });
   return;
 });

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -124,7 +124,7 @@ paths:
                 properties:
                   token:
                     type: string
-                    description: JWT authentication token (expires after 30 minutes)
+                    description: JWT authentication token containing user id and email (expires after 30 minutes)
                     example: >-
                       eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjEsImlhdCI6MT
                       Y4NTg0OTc1NX0.LXrlo3wrX7rQiGZnYuxRKgXUxRvQPgFP5yxv1rdqe8E

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -47,6 +47,7 @@ describe('Auth endpoints', () => {
       expect(typeof res.body.token).toBe('string');
       const payload = verify(res.body.token, 'development-secret');
       expect(payload.userId).toBe(1);
+      expect(payload.email).toBe('test@example.com');
       expect(payload.exp - payload.iat).toBe(1800);
     });
 
@@ -59,7 +60,7 @@ describe('Auth endpoints', () => {
     });
 
     it('rejects expired tokens', () => {
-      const token = sign({ userId: 1 }, 'development-secret', -1);
+      const token = sign({ userId: 1, email: 'test@example.com' }, 'development-secret', -1);
       expect(() => verify(token, 'development-secret')).toThrow('Token expired');
     });
   });

--- a/test/health.test.ts
+++ b/test/health.test.ts
@@ -13,7 +13,7 @@ describe('GET /health', () => {
 
   it('returns database ok when query succeeds', async () => {
     mockedPrisma.$queryRaw.mockResolvedValueOnce(1 as any);
-    const token = sign({ userId: 1 }, 'development-secret');
+    const token = sign({ userId: 1, email: 'test@example.com' }, 'development-secret');
     const res = await request(app)
       .get('/health')
       .set('Authorization', `Bearer ${token}`);
@@ -23,7 +23,7 @@ describe('GET /health', () => {
 
   it('returns database error when query fails', async () => {
     mockedPrisma.$queryRaw.mockRejectedValueOnce(new Error('fail'));
-    const token = sign({ userId: 1 }, 'development-secret');
+    const token = sign({ userId: 1, email: 'test@example.com' }, 'development-secret');
     const res = await request(app)
       .get('/health')
       .set('Authorization', `Bearer ${token}`);

--- a/test/programs.test.ts
+++ b/test/programs.test.ts
@@ -18,7 +18,7 @@ describe('GET /programs/:username', () => {
       { role: 'admin', program: { id: 'abc123', name: 'Boys State Texas' } },
       { role: 'counselor', program: { id: 'def456', name: 'Girls State Florida' } },
     ]);
-    const token = sign({ userId: 1 }, 'development-secret');
+    const token = sign({ userId: 1, email: 'jane.doe' }, 'development-secret');
     const res = await request(app)
       .get('/programs/jane.doe')
       .set('Authorization', `Bearer ${token}`);
@@ -35,7 +35,7 @@ describe('GET /programs/:username', () => {
   it('returns empty array when user has no programs', async () => {
     mockedPrisma.user.findUnique.mockResolvedValueOnce({ id: 2, email: 'jane.doe' });
     mockedPrisma.programAssignment.findMany.mockResolvedValueOnce([]);
-    const token = sign({ userId: 2 }, 'development-secret');
+    const token = sign({ userId: 2, email: 'jane.doe' }, 'development-secret');
     const res = await request(app)
       .get('/programs/jane.doe')
       .set('Authorization', `Bearer ${token}`);


### PR DESCRIPTION
## Summary
- add user email to JWT payload returned on login
- update OpenAPI docs
- adjust tests for new payload data

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6864a4908d64832d8df4ca219909d788