### PR TITLE
Update docs for build step requirement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,7 @@ Thank you for your interest in contributing to the Boys State App backend! Wheth
    npm run lint
    # or relevant test commands
    ```
+4. After tests pass, run `npm run build` to regenerate the `dist/` folder.
 4. Update the Swagger/OpenAPI docs as needed.
 5. Submit a PR referencing any related issues or cross-repo features.
 6. Collaborate on code review; be ready for feedback/changes.

--- a/README.md
+++ b/README.md
@@ -53,5 +53,6 @@ See [`AGENTS.md`](./AGENTS.md) for a full list of backend agents and integration
 ## Contributing
 
 * All changes must include tests and clear documentation.
+* After running tests, execute `npm run build` to update the `dist/` folder before opening a PR.
 * PRs must pass CI and code review before merge.
 * For mobile or admin UI, see [Mobile App](https://github.com/yourorg/boysstate-mobile) and [Web Admin Portal](https://github.com/yourorg/boysstate-admin).


### PR DESCRIPTION
## Summary
- mention running `npm run build` after tests in README
- note the same build step in CONTRIBUTING

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_686512669f64832dab93ecee8e244185