### PR TITLE
Introduce per-program logging utility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 
 /generated/prisma
 /coverage
+logs/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,6 +154,8 @@ This document describes the backend service agents supporting the Boys State App
 * **Sensitive info:** Strict compliance with privacy standards for minors (COPPA, FERPA, GDPR, etc.).
 * **Authentication:** All access must be authenticated and authorized.
 * **Logging:** All backend communication, actions, and errors are logged. Sensitive data is redacted as appropriate.
+  * Use the `src/logger.ts` utility for all logs instead of `console.log`.
+  * Each log entry records a `programId` to keep logs isolated per program and are written to `logs/<programId>.log` in JSON lines format.
 * **Branding/config:** All branding and configuration are managed and loaded per program.
 * **Automated testing:** All business logic and endpoints require automated tests for core logic, error cases, and edge scenarios.
 

--- a/dist/logger.js
+++ b/dist/logger.js
@@ -1,0 +1,34 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.info = info;
+exports.error = error;
+const fs_1 = require("fs");
+const path_1 = __importDefault(require("path"));
+function writeLog(entry) {
+    const logsDir = path_1.default.join(__dirname, '..', 'logs');
+    if (!(0, fs_1.existsSync)(logsDir)) {
+        (0, fs_1.mkdirSync)(logsDir, { recursive: true });
+    }
+    const file = path_1.default.join(logsDir, `${entry.programId}.log`);
+    (0, fs_1.appendFileSync)(file, JSON.stringify(entry) + '\n');
+}
+function info(programId, message) {
+    writeLog({
+        timestamp: new Date().toISOString(),
+        level: 'info',
+        programId,
+        message,
+    });
+}
+function error(programId, message, err) {
+    writeLog({
+        timestamp: new Date().toISOString(),
+        level: 'error',
+        programId,
+        message,
+        error: err ? (err instanceof Error ? err.stack || err.message : String(err)) : undefined,
+    });
+}

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,38 @@
+import { appendFileSync, mkdirSync, existsSync } from 'fs';
+import path from 'path';
+
+interface LogEntry {
+  timestamp: string;
+  level: 'info' | 'error';
+  programId: string;
+  message: string;
+  error?: string;
+}
+
+function writeLog(entry: LogEntry) {
+  const logsDir = path.join(__dirname, '..', 'logs');
+  if (!existsSync(logsDir)) {
+    mkdirSync(logsDir, { recursive: true });
+  }
+  const file = path.join(logsDir, `${entry.programId}.log`);
+  appendFileSync(file, JSON.stringify(entry) + '\n');
+}
+
+export function info(programId: string, message: string) {
+  writeLog({
+    timestamp: new Date().toISOString(),
+    level: 'info',
+    programId,
+    message,
+  });
+}
+
+export function error(programId: string, message: string, err?: unknown) {
+  writeLog({
+    timestamp: new Date().toISOString(),
+    level: 'error',
+    programId,
+    message,
+    error: err ? (err instanceof Error ? err.stack || err.message : String(err)) : undefined,
+  });
+}


### PR DESCRIPTION
## Summary
- create `src/logger.ts` with a simple file-based logger
- record requests and errors with program context
- ignore generated log files
- document logging utility in `AGENTS.md`
- rebuild `dist`

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68651269115c832d8932aed7132e54ab