### PR TITLE
Add swagger.json endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ This repository contains the **backend REST API and core services** for Boys Sta
 6. **API documentation:**
 
    * Access Swagger/OpenAPI docs at `/docs` or as configured.
+   * Download the raw Swagger spec at `/docs/swagger.json`.
 
 ## Agent Specification
 

--- a/__tests__/docs.test.ts
+++ b/__tests__/docs.test.ts
@@ -7,4 +7,10 @@ describe('GET /docs', () => {
     const res = await request(app).get('/docs');
     expect(res.status).not.toBe(401);
   });
+
+  it('can return swagger.json', async () => {
+    const res = await request(app).get('/docs/swagger.json');
+    expect(res.status).toBe(200);
+    expect(res.body.openapi).toBe('3.0.0');
+  });
 });

--- a/__tests__/jwt.test.ts
+++ b/__tests__/jwt.test.ts
@@ -1,0 +1,14 @@
+import { sign, verify } from '../src/jwt';
+
+describe('jwt verify', () => {
+  it('throws for invalid token structure', () => {
+    expect(() => verify('nope', 'secret')).toThrow('Invalid token');
+  });
+
+  it('throws for invalid signature', () => {
+    const token = sign({ userId: 1 }, 'secret');
+    const parts = token.split('.');
+    const tampered = `${parts[0]}.${parts[1]}.badsig`;
+    expect(() => verify(tampered, 'secret')).toThrow('Invalid signature');
+  });
+});

--- a/__tests__/logger.test.ts
+++ b/__tests__/logger.test.ts
@@ -1,0 +1,48 @@
+jest.mock('fs');
+import { appendFileSync, mkdirSync, existsSync } from 'fs';
+import * as logger from '../src/logger';
+
+const mockedFs = {
+  appendFileSync: appendFileSync as jest.Mock,
+  mkdirSync: mkdirSync as jest.Mock,
+  existsSync: existsSync as jest.Mock,
+};
+
+beforeEach(() => {
+  mockedFs.appendFileSync.mockReset();
+  mockedFs.mkdirSync.mockReset();
+  mockedFs.existsSync.mockReset();
+});
+
+test('info creates log directory when missing', () => {
+  mockedFs.existsSync.mockReturnValueOnce(false);
+  logger.info('test', 'hello');
+  expect(mockedFs.mkdirSync).toHaveBeenCalled();
+  expect(mockedFs.appendFileSync).toHaveBeenCalled();
+});
+
+test('error logs with stack string', () => {
+  mockedFs.existsSync.mockReturnValue(true);
+  const err = new Error('bad');
+  logger.error('test', 'oops', err);
+  const call = mockedFs.appendFileSync.mock.calls[0][1] as string;
+  const entry = JSON.parse(call);
+  expect(entry.error).toContain('bad');
+});
+
+
+test('error logs without error argument', () => {
+  mockedFs.existsSync.mockReturnValue(true);
+  logger.error('test', 'missing');
+  const call = mockedFs.appendFileSync.mock.calls[0][1] as string;
+  const entry = JSON.parse(call);
+  expect(entry.error).toBeUndefined();
+});
+
+test('error logs string error', () => {
+  mockedFs.existsSync.mockReturnValue(true);
+  logger.error('test', 'oops', 'bad');
+  const call = mockedFs.appendFileSync.mock.calls[0][1] as string;
+  const entry = JSON.parse(call);
+  expect(entry.error).toBe('bad');
+});

--- a/dist/index.js
+++ b/dist/index.js
@@ -91,6 +91,9 @@ function ensureDatabase() {
 // Load OpenAPI spec
 const openApiPath = path_1.default.join(__dirname, 'openapi.yaml');
 const openApiDoc = yaml_1.default.parse((0, fs_1.readFileSync)(openApiPath, 'utf8'));
+app.get('/docs/swagger.json', (_req, res) => {
+    res.json(openApiDoc);
+});
 app.use('/docs', swagger_ui_express_1.default.serve, swagger_ui_express_1.default.setup(openApiDoc));
 app.post('/register', async (req, res) => {
     const { email, password } = req.body;

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,9 @@ function ensureDatabase() {
 // Load OpenAPI spec
 const openApiPath = path.join(__dirname, 'openapi.yaml');
 const openApiDoc = yaml.parse(readFileSync(openApiPath, 'utf8'));
+app.get('/docs/swagger.json', (_req, res) => {
+  res.json(openApiDoc);
+});
 app.use('/docs', swaggerUi.serve, swaggerUi.setup(openApiDoc));
 
 app.post('/register', async (req: express.Request, res: express.Response) => {


### PR DESCRIPTION
## Summary
- expose `/docs/swagger.json` endpoint for raw swagger spec
- update docs test to cover JSON download
- document swagger.json in README
- add JWT and logger unit tests for improved coverage

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_686522688a1c832da872e2e0f85715a9