### PR TITLE
Dynamic local Swagger server

### DIFF
--- a/__tests__/docs.test.ts
+++ b/__tests__/docs.test.ts
@@ -1,10 +1,14 @@
 import request from 'supertest';
 jest.mock('../src/prisma');
-import app from '../src/index';
+import app, { swaggerDoc } from '../src/index';
 
 describe('GET /docs', () => {
   it('is accessible without authentication', async () => {
     const res = await request(app).get('/docs');
     expect(res.status).not.toBe(401);
+  });
+
+  it('uses a local server url when not in production', () => {
+    expect(swaggerDoc.servers[0].url).toMatch('http://localhost');
   });
 });

--- a/dist/index.js
+++ b/dist/index.js
@@ -36,6 +36,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.swaggerDoc = void 0;
 exports.getUserPrograms = getUserPrograms;
 const express_1 = __importDefault(require("express"));
 const cors_1 = __importDefault(require("cors"));
@@ -91,7 +92,13 @@ function ensureDatabase() {
 // Load OpenAPI spec
 const openApiPath = path_1.default.join(__dirname, 'openapi.yaml');
 const openApiDoc = yaml_1.default.parse((0, fs_1.readFileSync)(openApiPath, 'utf8'));
+// Override server URL when not in production so Swagger points to the local API
+const port = process.env.PORT || 3000;
+if (process.env.NODE_ENV !== 'production') {
+    openApiDoc.servers = [{ url: `http://localhost:${port}` }];
+}
 app.use('/docs', swagger_ui_express_1.default.serve, swagger_ui_express_1.default.setup(openApiDoc));
+exports.swaggerDoc = openApiDoc;
 app.post('/register', async (req, res) => {
     const { email, password } = req.body;
     if (!email || !password) {
@@ -171,7 +178,6 @@ async function getUserPrograms(req, res) {
     res.json({ username: user.email, programs });
 }
 app.get('/programs/:username', getUserPrograms);
-const port = process.env.PORT || 3000;
 if (process.env.NODE_ENV !== 'test') {
     ensureDatabase();
     app.listen(port, () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,16 @@ function ensureDatabase() {
 // Load OpenAPI spec
 const openApiPath = path.join(__dirname, 'openapi.yaml');
 const openApiDoc = yaml.parse(readFileSync(openApiPath, 'utf8'));
+
+// Override server URL when not in production so Swagger points to the local API
+const port = process.env.PORT || 3000;
+if (process.env.NODE_ENV !== 'production') {
+  openApiDoc.servers = [{ url: `http://localhost:${port}` }];
+}
+
 app.use('/docs', swaggerUi.serve, swaggerUi.setup(openApiDoc));
+
+export const swaggerDoc = openApiDoc;
 
 app.post('/register', async (req: express.Request, res: express.Response) => {
   const { email, password } = req.body as { email?: string; password?: string };
@@ -155,7 +164,6 @@ export async function getUserPrograms(
 
 app.get('/programs/:username', getUserPrograms);
 
-const port = process.env.PORT || 3000;
 if (process.env.NODE_ENV !== 'test') {
   ensureDatabase();
   app.listen(port, () => {


### PR DESCRIPTION
## Summary
- override OpenAPI `servers` when not in production so Swagger points to the local service
- export the parsed swagger document and test for the local server URL

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_686523404a98832da96ce6a7b498ddae