### PR TITLE
Implement database-backed logging system

### DIFF
--- a/dist/logger.js
+++ b/dist/logger.js
@@ -3,10 +3,13 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.debug = debug;
 exports.info = info;
+exports.warn = warn;
 exports.error = error;
 const fs_1 = require("fs");
 const path_1 = __importDefault(require("path"));
+const prisma_1 = __importDefault(require("./prisma"));
 function writeLog(entry) {
     const logsDir = path_1.default.join(__dirname, '..', 'logs');
     if (!(0, fs_1.existsSync)(logsDir)) {
@@ -14,21 +17,59 @@ function writeLog(entry) {
     }
     const file = path_1.default.join(logsDir, `${entry.programId}.log`);
     (0, fs_1.appendFileSync)(file, JSON.stringify(entry) + '\n');
+    prisma_1.default.log
+        .create({
+        data: {
+            timestamp: new Date(entry.timestamp),
+            level: entry.level,
+            source: entry.source,
+            programId: entry.programId,
+            message: entry.message,
+            error: entry.error,
+        },
+    })
+        .catch(() => {
+        /* ignore logging failures */
+    });
 }
-function info(programId, message) {
+function debug(programId, message, source = 'api') {
+    writeLog({
+        timestamp: new Date().toISOString(),
+        level: 'debug',
+        programId,
+        source,
+        message,
+    });
+}
+function info(programId, message, source = 'api') {
     writeLog({
         timestamp: new Date().toISOString(),
         level: 'info',
         programId,
+        source,
         message,
     });
 }
-function error(programId, message, err) {
+function warn(programId, message, source = 'api') {
+    writeLog({
+        timestamp: new Date().toISOString(),
+        level: 'warn',
+        programId,
+        source,
+        message,
+    });
+}
+function error(programId, message, err, source = 'api') {
     writeLog({
         timestamp: new Date().toISOString(),
         level: 'error',
         programId,
+        source,
         message,
-        error: err ? (err instanceof Error ? err.stack || err.message : String(err)) : undefined,
+        error: err
+            ? err instanceof Error
+                ? err.stack || err.message
+                : String(err)
+            : undefined,
     });
 }

--- a/dist/openapi.yaml
+++ b/dist/openapi.yaml
@@ -171,7 +171,7 @@ paths:
                 level:
                   type: string
                   description: Log level
-                  enum: [info, error]
+                  enum: [debug, info, warn, error]
                   example: info
                 message:
                   type: string
@@ -181,6 +181,10 @@ paths:
                   type: string
                   description: Optional error details for error logs
                   example: Stack trace
+                source:
+                  type: string
+                  description: Where the log originated (api or client)
+                  example: client
       responses:
         '204':
           description: Log recorded

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -40,3 +40,14 @@ model ProgramAssignment {
   role      String
   createdAt DateTime @default(now())
 }
+
+model Log {
+  id        Int      @id @default(autoincrement())
+  timestamp DateTime @default(now())
+  level     String
+  source    String
+  programId String
+  message   String
+  error     String?
+}
+

--- a/src/__mocks__/prisma.ts
+++ b/src/__mocks__/prisma.ts
@@ -7,6 +7,9 @@ const prisma = {
   programAssignment: {
     findMany: jest.fn(),
   },
+  log: {
+    create: jest.fn().mockResolvedValue(null),
+  },
 };
 
 export default prisma;

--- a/src/index.ts
+++ b/src/index.ts
@@ -136,24 +136,36 @@ app.get('/health', async (_req, res) => {
 });
 
 app.post('/logs', (req: express.Request, res: express.Response) => {
-  const { programId, level, message, error } = req.body as {
+  const { programId, level, message, error, source } = req.body as {
     programId?: string;
     level?: string;
     message?: string;
     error?: string;
+    source?: string;
   };
   if (!programId || !level || !message) {
     res.status(400).json({ error: 'programId, level, and message required' });
     return;
   }
-  if (level !== 'info' && level !== 'error') {
+  const lvl = level as string;
+  if (!['debug', 'info', 'warn', 'error'].includes(lvl)) {
     res.status(400).json({ error: 'Invalid level' });
     return;
   }
-  if (level === 'info') {
-    logger.info(programId, message);
-  } else {
-    logger.error(programId, message, error);
+  const src = source || 'client';
+  switch (lvl) {
+    case 'debug':
+      logger.debug(programId, message, src);
+      break;
+    case 'info':
+      logger.info(programId, message, src);
+      break;
+    case 'warn':
+      logger.warn(programId, message, src);
+      break;
+    case 'error':
+      logger.error(programId, message, error, src);
+      break;
   }
   res.status(204).send();
 });

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,10 +1,14 @@
 import { appendFileSync, mkdirSync, existsSync } from 'fs';
 import path from 'path';
+import prisma from './prisma';
+
+type LogLevel = 'debug' | 'info' | 'warn' | 'error';
 
 interface LogEntry {
   timestamp: string;
-  level: 'info' | 'error';
+  level: LogLevel;
   programId: string;
+  source: string;
   message: string;
   error?: string;
 }
@@ -16,23 +20,68 @@ function writeLog(entry: LogEntry) {
   }
   const file = path.join(logsDir, `${entry.programId}.log`);
   appendFileSync(file, JSON.stringify(entry) + '\n');
+  prisma.log
+    .create({
+      data: {
+        timestamp: new Date(entry.timestamp),
+        level: entry.level,
+        source: entry.source,
+        programId: entry.programId,
+        message: entry.message,
+        error: entry.error,
+      },
+    })
+    .catch(() => {
+      /* ignore logging failures */
+    });
 }
 
-export function info(programId: string, message: string) {
+export function debug(programId: string, message: string, source = 'api') {
   writeLog({
     timestamp: new Date().toISOString(),
-    level: 'info',
+    level: 'debug',
     programId,
+    source,
     message,
   });
 }
 
-export function error(programId: string, message: string, err?: unknown) {
+export function info(programId: string, message: string, source = 'api') {
+  writeLog({
+    timestamp: new Date().toISOString(),
+    level: 'info',
+    programId,
+    source,
+    message,
+  });
+}
+
+export function warn(programId: string, message: string, source = 'api') {
+  writeLog({
+    timestamp: new Date().toISOString(),
+    level: 'warn',
+    programId,
+    source,
+    message,
+  });
+}
+
+export function error(
+  programId: string,
+  message: string,
+  err?: unknown,
+  source = 'api',
+) {
   writeLog({
     timestamp: new Date().toISOString(),
     level: 'error',
     programId,
+    source,
     message,
-    error: err ? (err instanceof Error ? err.stack || err.message : String(err)) : undefined,
+    error: err
+      ? err instanceof Error
+        ? err.stack || err.message
+        : String(err)
+      : undefined,
   });
 }

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -171,7 +171,7 @@ paths:
                 level:
                   type: string
                   description: Log level
-                  enum: [info, error]
+                  enum: [debug, info, warn, error]
                   example: info
                 message:
                   type: string
@@ -181,6 +181,10 @@ paths:
                   type: string
                   description: Optional error details for error logs
                   example: Stack trace
+                source:
+                  type: string
+                  description: Where the log originated (api or client)
+                  example: client
       responses:
         '204':
           description: Log recorded


### PR DESCRIPTION
## Summary
- track log level and source in new `Log` table
- extend logger utility to write to file and database
- allow `debug` and `warn` levels through the logs endpoint
- update OpenAPI spec and compiled output
- update tests for new logging behavior

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68666edffaec832d939c1b81a908d53f