### PR TITLE
Add Swagger download link

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ This repository contains the **backend REST API and core services** for Boys Sta
 6. **API documentation:**
 
    * Access Swagger/OpenAPI docs at `/docs` or as configured.
-   * Download the raw Swagger spec at `/docs/swagger.json`.
+   * Download the raw Swagger spec at `/docs/swagger.json` or via the link on the Swagger UI page.
 
 ## Agent Specification
 

--- a/__tests__/docs.test.ts
+++ b/__tests__/docs.test.ts
@@ -14,6 +14,17 @@ describe('GET /docs', () => {
     expect(res.status).toBe(200);
     expect(res.body.openapi).toBe('3.0.0');
   });
+
+  it('contains a download link for swagger.json', async () => {
+    const res = await request(app).get('/docs/');
+    expect(res.text).toMatch('swagger-ui-custom.js');
+  });
+
+  it('serves the custom javascript', async () => {
+    const res = await request(app).get('/docs/swagger-ui-custom.js');
+    expect(res.status).toBe(200);
+    expect(res.text).toMatch('Download swagger.json');
+  });
     
   it('uses a local server url when not in production', () => {
     expect(swaggerDoc.servers[0].url).toMatch('http://localhost');

--- a/dist/index.js
+++ b/dist/index.js
@@ -100,7 +100,13 @@ const port = process.env.PORT || 3000;
 if (process.env.NODE_ENV !== 'production') {
     openApiDoc.servers = [{ url: `http://localhost:${port}` }];
 }
-app.use('/docs', swagger_ui_express_1.default.serve, swagger_ui_express_1.default.setup(openApiDoc));
+app.get('/docs/swagger-ui-custom.js', (_req, res) => {
+    res.sendFile(path_1.default.join(__dirname, 'swagger-ui-custom.js'));
+});
+const docsOptions = {
+    customJs: 'swagger-ui-custom.js',
+};
+app.use('/docs', swagger_ui_express_1.default.serve, swagger_ui_express_1.default.setup(openApiDoc, docsOptions));
 exports.swaggerDoc = openApiDoc;
 app.post('/register', async (req, res) => {
     const { email, password } = req.body;

--- a/dist/swagger-ui-custom.js
+++ b/dist/swagger-ui-custom.js
@@ -1,0 +1,9 @@
+window.addEventListener('load', function () {
+  const container = document.querySelector('body .topbar');
+  if (!container) return;
+  const link = document.createElement('a');
+  link.href = 'swagger.json';
+  link.innerText = 'Download swagger.json';
+  link.style.marginLeft = '10px';
+  container.appendChild(link);
+});

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "pretest": "npm run prisma:generate",
     "test": "jest",
     "dev": "ts-node src/index.ts",
-    "build": "tsc && cp src/openapi.yaml dist/openapi.yaml",
+    "build": "tsc && cp src/openapi.yaml dist/openapi.yaml && cp src/swagger-ui-custom.js dist/swagger-ui-custom.js",
     "start": "node dist/index.js",
     "prisma:migrate": "prisma migrate dev",
     "prisma:generate": "prisma generate"

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,7 +70,15 @@ if (process.env.NODE_ENV !== 'production') {
   openApiDoc.servers = [{ url: `http://localhost:${port}` }];
 }
 
-app.use('/docs', swaggerUi.serve, swaggerUi.setup(openApiDoc));
+app.get('/docs/swagger-ui-custom.js', (_req, res) => {
+  res.sendFile(path.join(__dirname, 'swagger-ui-custom.js'));
+});
+
+const docsOptions = {
+  customJs: 'swagger-ui-custom.js',
+};
+
+app.use('/docs', swaggerUi.serve, swaggerUi.setup(openApiDoc, docsOptions));
 
 export const swaggerDoc = openApiDoc;
 

--- a/src/swagger-ui-custom.js
+++ b/src/swagger-ui-custom.js
@@ -1,0 +1,9 @@
+window.addEventListener('load', function () {
+  const container = document.querySelector('body .topbar');
+  if (!container) return;
+  const link = document.createElement('a');
+  link.href = 'swagger.json';
+  link.innerText = 'Download swagger.json';
+  link.style.marginLeft = '10px';
+  container.appendChild(link);
+});


### PR DESCRIPTION
## Summary
- add a small script that injects a download link on the Swagger UI
- serve the custom JS and wire it into Swagger setup
- document the link in README
- test new behaviour
- compile the project

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6866736235a8832da06ce011396aa1ad