### PR TITLE
Implement login rate limiting

### DIFF
--- a/__tests__/auth.test.ts
+++ b/__tests__/auth.test.ts
@@ -1,7 +1,7 @@
 import request from 'supertest';
 jest.mock('../src/prisma');
 import prisma from '../src/prisma';
-import app from '../src/index';
+import app, { loginAttempts } from '../src/index';
 import { verify, sign } from '../src/jwt';
 
 const mockedPrisma = prisma as any;
@@ -11,6 +11,7 @@ describe('Auth endpoints', () => {
     mockedPrisma.user.findUnique.mockReset();
     mockedPrisma.user.create.mockReset();
     jest.restoreAllMocks();
+    loginAttempts.clear();
   });
 
   describe('POST /register', () => {
@@ -23,6 +24,11 @@ describe('Auth endpoints', () => {
       expect(res.status).toBe(201);
       expect(res.body).toEqual({ message: 'User created' });
       expect(mockedPrisma.user.create).toHaveBeenCalled();
+    });
+
+    it('requires email and password', async () => {
+      const res = await request(app).post('/register').send({});
+      expect(res.status).toBe(400);
     });
 
     it('fails when user exists', async () => {
@@ -57,6 +63,49 @@ describe('Auth endpoints', () => {
         .post('/login')
         .send({ email: 'bad@example.com', password: 'nope' });
       expect(res.status).toBe(401);
+    });
+
+    it('requires email and password', async () => {
+      const res = await request(app).post('/login').send({});
+      expect(res.status).toBe(400);
+    });
+
+    it('rate limits after repeated failures', async () => {
+      mockedPrisma.user.findUnique.mockResolvedValue(null as any);
+      for (let i = 0; i < 5; i++) {
+        const res = await request(app)
+          .post('/login')
+          .send({ email: 'bad@example.com', password: 'nope' });
+        expect(res.status).toBe(401);
+      }
+      const res = await request(app)
+        .post('/login')
+        .send({ email: 'bad@example.com', password: 'nope' });
+      expect(res.status).toBe(429);
+    });
+
+    it('clears failed attempt count after successful login', async () => {
+      const hash = '05ffaebcca41770af425d4ba9b4e7bcdff532237dca931c192a36d94db7307d4c2df95e606514b4113ccb3ad3c19f7ca648e373a112a6b8290f3a69818aa9b7e';
+      const passwordHash = `salt:${hash}`;
+      mockedPrisma.user.findUnique.mockResolvedValue(null as any);
+      for (let i = 0; i < 2; i++) {
+        await request(app)
+          .post('/login')
+          .send({ email: 'bad@example.com', password: 'nope' });
+      }
+      mockedPrisma.user.findUnique.mockResolvedValue({ id: 1, email: 'test@example.com', password: passwordHash } as any);
+      const success = await request(app)
+        .post('/login')
+        .send({ email: 'test@example.com', password: 'secret' });
+      expect(success.status).toBe(200);
+
+      mockedPrisma.user.findUnique.mockResolvedValue(null as any);
+      for (let i = 0; i < 5; i++) {
+        const res = await request(app)
+          .post('/login')
+          .send({ email: 'bad@example.com', password: 'nope' });
+        expect(res.status).toBe(401);
+      }
     });
 
     it('rejects expired tokens', () => {

--- a/__tests__/database.test.ts
+++ b/__tests__/database.test.ts
@@ -1,0 +1,29 @@
+import { ensureDatabase } from '../src/index';
+import * as child_process from 'child_process';
+import * as logger from '../src/logger';
+
+jest.mock('child_process');
+jest.mock('../src/logger');
+
+const execMock = child_process.execSync as jest.Mock;
+
+beforeEach(() => {
+  execMock.mockReset();
+  (logger.info as jest.Mock).mockReset();
+  (logger.error as jest.Mock).mockReset();
+});
+
+describe('ensureDatabase', () => {
+  it('runs database sync', () => {
+    execMock.mockImplementationOnce(() => {});
+    ensureDatabase();
+    expect(execMock).toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith('system', 'Running database synchronization');
+  });
+
+  it('logs errors on failure', () => {
+    execMock.mockImplementationOnce(() => { throw new Error('fail'); });
+    ensureDatabase();
+    expect(logger.error).toHaveBeenCalled();
+  });
+});

--- a/__tests__/health.test.ts
+++ b/__tests__/health.test.ts
@@ -30,4 +30,9 @@ describe('GET /health', () => {
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ status: 'ok', database: 'error' });
   });
+
+  it('requires authentication', async () => {
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(401);
+  });
 });

--- a/dist/openapi.yaml
+++ b/dist/openapi.yaml
@@ -148,6 +148,16 @@ paths:
                   error:
                     type: string
                     example: Invalid credentials
+        '429':
+          description: Too many failed login attempts
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: Too many login attempts
 
   /logs:
     post:

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,10 @@ app.use((req, _res, next) => {
 
 const jwtSecret = process.env.JWT_SECRET || 'development-secret';
 
+const loginAttempts = new Map<string, { count: number; lastAttempt: number }>();
+const MAX_LOGIN_ATTEMPTS = 5;
+const LOGIN_WINDOW_MS = 15 * 60 * 1000; // 15 minutes
+
 app.use((req, res, next) => {
   if (
     req.path === '/login' ||
@@ -117,8 +121,19 @@ app.post('/login', async (req: express.Request, res: express.Response) => {
     return;
   }
 
+  const now = Date.now();
+  const ip = req.ip || '';
+  const attempt = loginAttempts.get(ip);
+  if (attempt && now - attempt.lastAttempt < LOGIN_WINDOW_MS && attempt.count >= MAX_LOGIN_ATTEMPTS) {
+    logger.warn('system', `Too many login attempts from ${ip}`);
+    res.status(429).json({ error: 'Too many login attempts' });
+    return;
+  }
+
   const user = await prisma.user.findUnique({ where: { email } });
   if (!user) {
+    const count = attempt && now - attempt.lastAttempt < LOGIN_WINDOW_MS ? attempt.count + 1 : 1;
+    loginAttempts.set(ip, { count, lastAttempt: now });
     res.status(401).json({ error: 'Invalid credentials' });
     return;
   }
@@ -126,9 +141,13 @@ app.post('/login', async (req: express.Request, res: express.Response) => {
   const [salt, storedHash] = user.password.split(':');
   const buf = (await scrypt(password, salt, 64)) as Buffer;
   if (buf.toString('hex') !== storedHash) {
+    const count = attempt && now - attempt.lastAttempt < LOGIN_WINDOW_MS ? attempt.count + 1 : 1;
+    loginAttempts.set(ip, { count, lastAttempt: now });
     res.status(401).json({ error: 'Invalid credentials' });
     return;
   }
+
+  loginAttempts.delete(ip);
 
   const token = sign({ userId: user.id, email: user.email }, jwtSecret);
   logger.info('system', `User logged in: ${email}`);
@@ -376,4 +395,5 @@ if (process.env.NODE_ENV !== 'test') {
   });
 }
 
+export { loginAttempts, ensureDatabase };
 export default app;

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -148,6 +148,16 @@ paths:
                   error:
                     type: string
                     example: Invalid credentials
+        '429':
+          description: Too many failed login attempts
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: Too many login attempts
 
   /logs:
     post:


### PR DESCRIPTION
## Summary
- protect login endpoint against brute-force attacks
- document new 429 response in OpenAPI spec
- export `loginAttempts` and `ensureDatabase` for testing
- add extensive tests covering rate limits and authorization
- add tests for database sync logging

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_686a99dc3354832da9c720b11762bb30