### PR TITLE
Add ProgramYear support

### DIFF
--- a/__tests__/programYears.test.ts
+++ b/__tests__/programYears.test.ts
@@ -1,0 +1,75 @@
+import request from 'supertest';
+jest.mock('../src/prisma');
+import prisma from '../src/prisma';
+import app from '../src/index';
+import { sign } from '../src/jwt';
+
+const mockedPrisma = prisma as any;
+const token = sign({ userId: 1, email: 'admin@example.com' }, 'development-secret');
+
+beforeEach(() => {
+  mockedPrisma.programAssignment.findFirst.mockReset();
+  mockedPrisma.programYear.create.mockReset();
+  mockedPrisma.programYear.findMany.mockReset();
+  mockedPrisma.programYear.findUnique.mockReset();
+  mockedPrisma.programYear.update.mockReset();
+});
+
+describe('ProgramYear endpoints', () => {
+  it('creates a program year when admin', async () => {
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'admin' });
+    mockedPrisma.programYear.create.mockResolvedValueOnce({ id: 1, programId: 'abc', year: 2025 });
+    const res = await request(app)
+      .post('/programs/abc/years')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ year: 2025 });
+    expect(res.status).toBe(201);
+    expect(mockedPrisma.programYear.create).toHaveBeenCalled();
+  });
+
+  it('lists program years for member', async () => {
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'delegate' });
+    mockedPrisma.programYear.findMany.mockResolvedValueOnce([{ id: 1, programId: 'abc', year: 2025 }]);
+    const res = await request(app)
+      .get('/programs/abc/years')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body.length).toBe(1);
+  });
+
+  it('gets program year details for member', async () => {
+    mockedPrisma.programYear.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc', year: 2025 });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'delegate' });
+    const res = await request(app)
+      .get('/program-years/1')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body.id).toBe(1);
+  });
+
+  it('updates program year when admin', async () => {
+    mockedPrisma.programYear.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc', year: 2025 });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'admin' });
+    mockedPrisma.programYear.update.mockResolvedValueOnce({ id: 1, programId: 'abc', year: 2025, status: 'archived' });
+    const res = await request(app)
+      .put('/program-years/1')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ status: 'archived' });
+    expect(res.status).toBe(200);
+    expect(mockedPrisma.programYear.update).toHaveBeenCalled();
+  });
+
+  it('archives program year', async () => {
+    mockedPrisma.programYear.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc', year: 2025 });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'admin' });
+    mockedPrisma.programYear.update.mockResolvedValueOnce({ id: 1, programId: 'abc', year: 2025, status: 'archived' });
+    const res = await request(app)
+      .delete('/program-years/1')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(mockedPrisma.programYear.update).toHaveBeenCalledWith({
+      where: { id: 1 },
+      data: { status: 'archived' },
+    });
+  });
+});

--- a/dist/index.js
+++ b/dist/index.js
@@ -266,6 +266,12 @@ async function isProgramAdmin(userId, programId) {
     });
     return assignment?.role === 'admin';
 }
+async function isProgramMember(userId, programId) {
+    const assignment = await prisma_1.default.programAssignment.findFirst({
+        where: { userId, programId },
+    });
+    return Boolean(assignment);
+}
 app.post('/programs', async (req, res) => {
     const user = req.user;
     const { name, year, config } = req.body;
@@ -339,6 +345,115 @@ app.get('/programs/:programId/users', async (req, res) => {
     });
     logger.info(programId, `Listed users for program`);
     res.json(assignments);
+});
+app.post('/programs/:programId/years', async (req, res) => {
+    const { programId } = req.params;
+    const caller = req.user;
+    if (!programId) {
+        res.status(400).json({ error: 'programId required' });
+        return;
+    }
+    const isAdmin = await isProgramAdmin(caller.userId, programId);
+    if (!isAdmin) {
+        res.status(403).json({ error: 'Forbidden' });
+        return;
+    }
+    const { year, startDate, endDate, status, notes } = req.body;
+    if (!year) {
+        res.status(400).json({ error: 'year required' });
+        return;
+    }
+    const py = await prisma_1.default.programYear.create({
+        data: {
+            programId,
+            year,
+            startDate: startDate ? new Date(startDate) : undefined,
+            endDate: endDate ? new Date(endDate) : undefined,
+            status: status || 'active',
+            notes,
+        },
+    });
+    logger.info(programId, `Program year ${year} created`);
+    res.status(201).json(py);
+});
+app.get('/programs/:programId/years', async (req, res) => {
+    const { programId } = req.params;
+    const caller = req.user;
+    if (!programId) {
+        res.status(400).json({ error: 'programId required' });
+        return;
+    }
+    const isMember = await isProgramMember(caller.userId, programId);
+    if (!isMember) {
+        res.status(403).json({ error: 'Forbidden' });
+        return;
+    }
+    const years = await prisma_1.default.programYear.findMany({
+        where: { programId },
+        orderBy: { year: 'desc' },
+    });
+    res.json(years);
+});
+app.get('/program-years/:id', async (req, res) => {
+    const { id } = req.params;
+    const caller = req.user;
+    const py = await prisma_1.default.programYear.findUnique({ where: { id: Number(id) } });
+    if (!py) {
+        res.status(404).json({ error: 'Not found' });
+        return;
+    }
+    const isMember = await isProgramMember(caller.userId, py.programId);
+    if (!isMember) {
+        res.status(403).json({ error: 'Forbidden' });
+        return;
+    }
+    res.json(py);
+});
+app.put('/program-years/:id', async (req, res) => {
+    const { id } = req.params;
+    const caller = req.user;
+    const py = await prisma_1.default.programYear.findUnique({ where: { id: Number(id) } });
+    if (!py) {
+        res.status(404).json({ error: 'Not found' });
+        return;
+    }
+    const isAdmin = await isProgramAdmin(caller.userId, py.programId);
+    if (!isAdmin) {
+        res.status(403).json({ error: 'Forbidden' });
+        return;
+    }
+    const { startDate, endDate, status, notes } = req.body;
+    const updated = await prisma_1.default.programYear.update({
+        where: { id: Number(id) },
+        data: {
+            startDate: startDate ? new Date(startDate) : undefined,
+            endDate: endDate ? new Date(endDate) : undefined,
+            status,
+            notes,
+        },
+    });
+    logger.info(py.programId, `Program year ${py.year} updated`);
+    res.json(updated);
+});
+app.delete('/program-years/:id', async (req, res) => {
+    const { id } = req.params;
+    const caller = req.user;
+    const py = await prisma_1.default.programYear.findUnique({ where: { id: Number(id) } });
+    if (!py) {
+        res.status(404).json({ error: 'Not found' });
+        return;
+    }
+    const isAdmin = await isProgramAdmin(caller.userId, py.programId);
+    if (!isAdmin) {
+        res.status(403).json({ error: 'Forbidden' });
+        return;
+    }
+    const updated = await prisma_1.default.programYear.update({
+        where: { id: Number(id) },
+        data: { status: 'archived' },
+    });
+    logger.info(py.programId, `Program year ${py.year} archived`);
+    res.json(updated);
 });
 app.get('/programs/:username', getUserPrograms);
 if (process.env.NODE_ENV !== 'test') {

--- a/dist/openapi.yaml
+++ b/dist/openapi.yaml
@@ -443,6 +443,142 @@ paths:
           description: Forbidden
       security:
         - bearerAuth: []
+  /programs/{programId}/years:
+    post:
+      tags: [programs]
+      summary: Create program year
+      parameters:
+        - in: path
+          name: programId
+          required: true
+          schema:
+            type: string
+          description: Program ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [year]
+              properties:
+                year:
+                  type: integer
+                  example: 2025
+                startDate:
+                  type: string
+                  format: date-time
+                endDate:
+                  type: string
+                  format: date-time
+                status:
+                  type: string
+                notes:
+                  type: string
+      responses:
+        '201':
+          description: Created program year
+        '400':
+          description: Invalid input
+        '403':
+          description: Forbidden
+      security:
+        - bearerAuth: []
+    get:
+      tags: [programs]
+      summary: List program years
+      parameters:
+        - in: path
+          name: programId
+          required: true
+          schema:
+            type: string
+          description: Program ID
+      responses:
+        '200':
+          description: Array of program years
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+        '403':
+          description: Forbidden
+      security:
+        - bearerAuth: []
+  /program-years/{id}:
+    get:
+      tags: [programs]
+      summary: Get program year
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Program year
+        '404':
+          description: Not found
+        '403':
+          description: Forbidden
+      security:
+        - bearerAuth: []
+    put:
+      tags: [programs]
+      summary: Update program year
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                startDate:
+                  type: string
+                  format: date-time
+                endDate:
+                  type: string
+                  format: date-time
+                status:
+                  type: string
+                notes:
+                  type: string
+      responses:
+        '200':
+          description: Updated program year
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+      security:
+        - bearerAuth: []
+    delete:
+      tags: [programs]
+      summary: Archive program year
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Archived program year
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+      security:
+        - bearerAuth: []
   /programs/{username}:
     get:
       tags: [programs]

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -30,6 +30,7 @@ model Program {
   createdBy   User               @relation("ProgramCreatedBy", fields: [createdById], references: [id])
   createdById Int
   assignments ProgramAssignment[]
+  years       ProgramYear[]
   createdAt   DateTime           @default(now())
 }
 
@@ -51,5 +52,18 @@ model Log {
   programId String
   message   String
   error     String?
+}
+
+model ProgramYear {
+  id        Int      @id @default(autoincrement())
+  program   Program  @relation(fields: [programId], references: [id])
+  programId String
+  year      Int
+  startDate DateTime?
+  endDate   DateTime?
+  status    String   @default("active")
+  notes     String?
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 }
 

--- a/src/__mocks__/prisma.ts
+++ b/src/__mocks__/prisma.ts
@@ -12,6 +12,12 @@ const prisma = {
   program: {
     create: jest.fn(),
   },
+  programYear: {
+    create: jest.fn(),
+    findMany: jest.fn(),
+    findUnique: jest.fn(),
+    update: jest.fn(),
+  },
   log: {
     create: jest.fn().mockResolvedValue(null),
     findMany: jest.fn(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -280,6 +280,13 @@ async function isProgramAdmin(userId: number, programId: string) {
   return assignment?.role === 'admin';
 }
 
+async function isProgramMember(userId: number, programId: string) {
+  const assignment = await prisma.programAssignment.findFirst({
+    where: { userId, programId },
+  });
+  return Boolean(assignment);
+}
+
 app.post('/programs', async (req: express.Request, res: express.Response) => {
   const user = (req as any).user as { userId: number; email: string };
   const { name, year, config } = req.body as {
@@ -366,6 +373,137 @@ app.get(
     res.json(assignments);
   },
 );
+
+app.post(
+  '/programs/:programId/years',
+  async (req: express.Request, res: express.Response) => {
+    const { programId } = req.params as { programId?: string };
+    const caller = (req as any).user as { userId: number; email: string };
+    if (!programId) {
+      res.status(400).json({ error: 'programId required' });
+      return;
+    }
+    const isAdmin = await isProgramAdmin(caller.userId, programId);
+    if (!isAdmin) {
+      res.status(403).json({ error: 'Forbidden' });
+      return;
+    }
+    const { year, startDate, endDate, status, notes } = req.body as {
+      year?: number;
+      startDate?: string;
+      endDate?: string;
+      status?: string;
+      notes?: string;
+    };
+    if (!year) {
+      res.status(400).json({ error: 'year required' });
+      return;
+    }
+    const py = await prisma.programYear.create({
+      data: {
+        programId,
+        year,
+        startDate: startDate ? new Date(startDate) : undefined,
+        endDate: endDate ? new Date(endDate) : undefined,
+        status: status || 'active',
+        notes,
+      },
+    });
+    logger.info(programId, `Program year ${year} created`);
+    res.status(201).json(py);
+  },
+);
+
+app.get(
+  '/programs/:programId/years',
+  async (req: express.Request, res: express.Response) => {
+    const { programId } = req.params as { programId?: string };
+    const caller = (req as any).user as { userId: number };
+    if (!programId) {
+      res.status(400).json({ error: 'programId required' });
+      return;
+    }
+    const isMember = await isProgramMember(caller.userId, programId);
+    if (!isMember) {
+      res.status(403).json({ error: 'Forbidden' });
+      return;
+    }
+    const years = await prisma.programYear.findMany({
+      where: { programId },
+      orderBy: { year: 'desc' },
+    });
+    res.json(years);
+  },
+);
+
+app.get('/program-years/:id', async (req: express.Request, res: express.Response) => {
+  const { id } = req.params as { id?: string };
+  const caller = (req as any).user as { userId: number };
+  const py = await prisma.programYear.findUnique({ where: { id: Number(id) } });
+  if (!py) {
+    res.status(404).json({ error: 'Not found' });
+    return;
+  }
+  const isMember = await isProgramMember(caller.userId, py.programId);
+  if (!isMember) {
+    res.status(403).json({ error: 'Forbidden' });
+    return;
+  }
+  res.json(py);
+});
+
+app.put('/program-years/:id', async (req: express.Request, res: express.Response) => {
+  const { id } = req.params as { id?: string };
+  const caller = (req as any).user as { userId: number };
+  const py = await prisma.programYear.findUnique({ where: { id: Number(id) } });
+  if (!py) {
+    res.status(404).json({ error: 'Not found' });
+    return;
+  }
+  const isAdmin = await isProgramAdmin(caller.userId, py.programId);
+  if (!isAdmin) {
+    res.status(403).json({ error: 'Forbidden' });
+    return;
+  }
+  const { startDate, endDate, status, notes } = req.body as {
+    startDate?: string;
+    endDate?: string;
+    status?: string;
+    notes?: string;
+  };
+  const updated = await prisma.programYear.update({
+    where: { id: Number(id) },
+    data: {
+      startDate: startDate ? new Date(startDate) : undefined,
+      endDate: endDate ? new Date(endDate) : undefined,
+      status,
+      notes,
+    },
+  });
+  logger.info(py.programId, `Program year ${py.year} updated`);
+  res.json(updated);
+});
+
+app.delete('/program-years/:id', async (req: express.Request, res: express.Response) => {
+  const { id } = req.params as { id?: string };
+  const caller = (req as any).user as { userId: number };
+  const py = await prisma.programYear.findUnique({ where: { id: Number(id) } });
+  if (!py) {
+    res.status(404).json({ error: 'Not found' });
+    return;
+  }
+  const isAdmin = await isProgramAdmin(caller.userId, py.programId);
+  if (!isAdmin) {
+    res.status(403).json({ error: 'Forbidden' });
+    return;
+  }
+  const updated = await prisma.programYear.update({
+    where: { id: Number(id) },
+    data: { status: 'archived' },
+  });
+  logger.info(py.programId, `Program year ${py.year} archived`);
+  res.json(updated);
+});
 
 app.get('/programs/:username', getUserPrograms);
 

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -443,6 +443,142 @@ paths:
           description: Forbidden
       security:
         - bearerAuth: []
+  /programs/{programId}/years:
+    post:
+      tags: [programs]
+      summary: Create program year
+      parameters:
+        - in: path
+          name: programId
+          required: true
+          schema:
+            type: string
+          description: Program ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [year]
+              properties:
+                year:
+                  type: integer
+                  example: 2025
+                startDate:
+                  type: string
+                  format: date-time
+                endDate:
+                  type: string
+                  format: date-time
+                status:
+                  type: string
+                notes:
+                  type: string
+      responses:
+        '201':
+          description: Created program year
+        '400':
+          description: Invalid input
+        '403':
+          description: Forbidden
+      security:
+        - bearerAuth: []
+    get:
+      tags: [programs]
+      summary: List program years
+      parameters:
+        - in: path
+          name: programId
+          required: true
+          schema:
+            type: string
+          description: Program ID
+      responses:
+        '200':
+          description: Array of program years
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+        '403':
+          description: Forbidden
+      security:
+        - bearerAuth: []
+  /program-years/{id}:
+    get:
+      tags: [programs]
+      summary: Get program year
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Program year
+        '404':
+          description: Not found
+        '403':
+          description: Forbidden
+      security:
+        - bearerAuth: []
+    put:
+      tags: [programs]
+      summary: Update program year
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                startDate:
+                  type: string
+                  format: date-time
+                endDate:
+                  type: string
+                  format: date-time
+                status:
+                  type: string
+                notes:
+                  type: string
+      responses:
+        '200':
+          description: Updated program year
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+      security:
+        - bearerAuth: []
+    delete:
+      tags: [programs]
+      summary: Archive program year
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Archived program year
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+      security:
+        - bearerAuth: []
   /programs/{username}:
     get:
       tags: [programs]


### PR DESCRIPTION
## Summary
- add `ProgramYear` Prisma model and relation to `Program`
- extend mocked Prisma client for programYear
- implement ProgramYear REST endpoints
- document endpoints in OpenAPI spec
- generate dist build
- add tests for program year features

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_686a9d9076d4832d887a3f7c7fede5b0