### PR TITLE
Update spec and add grouping endpoints

### DIFF
--- a/ProgramConfigSpec.md
+++ b/ProgramConfigSpec.md
@@ -4,7 +4,7 @@
 
 ## A. Core Tables & Relationships
 
-### 1. Program
+### 1. Program *(Implemented)*
 - `id` (PK)
 - `name`
 - `short_name`
@@ -17,7 +17,7 @@
 
 ---
 
-### 2. ProgramYear
+### 2. ProgramYear *(Implemented)*
 - `id` (PK)
 - `program_id` (FK → Program)
 - `year` (e.g., 2025)
@@ -30,7 +30,7 @@
 
 ---
 
-### 3. GroupingType
+### 3. GroupingType *(Implemented)*
 *(Flexible region/level naming per program)*
 - `id` (PK)
 - `program_id` (FK → Program)
@@ -45,7 +45,7 @@
 
 ---
 
-### 4. Grouping
+### 4. Grouping *(Partially Implemented: schema only)*
 *(Instances of each grouping type, with hierarchy)*
 - `id` (PK)
 - `program_id` (FK → Program)
@@ -60,7 +60,7 @@
 
 ---
 
-### 5. ProgramYearGrouping
+### 5. ProgramYearGrouping *(Partially Implemented: schema only)*
 *(Which groupings are active in which years)*
 - `id` (PK)
 - `program_year_id` (FK → ProgramYear)
@@ -69,7 +69,7 @@
 
 ---
 
-### 6. Party
+### 6. Party *(Not Implemented)*
 - `id` (PK)
 - `program_id` (FK → Program)
 - `name`
@@ -83,7 +83,7 @@
 
 ---
 
-### 7. ProgramYearParty
+### 7. ProgramYearParty *(Not Implemented)*
 - `id` (PK)
 - `program_year_id` (FK → ProgramYear)
 - `party_id` (FK → Party)
@@ -91,7 +91,7 @@
 
 ---
 
-### 8. Delegate
+### 8. Delegate *(Not Implemented)*
 - `id` (PK)
 - `program_year_id` (FK → ProgramYear)
 - `first_name`
@@ -107,7 +107,7 @@
 
 ---
 
-### 9. Staff
+### 9. Staff *(Not Implemented)*
 - `id` (PK)
 - `program_year_id` (FK → ProgramYear)
 - `first_name`
@@ -122,7 +122,7 @@
 
 ---
 
-### 10. Parent
+### 10. Parent *(Not Implemented)*
 - `id` (PK)
 - `user_id` (if linked to user account)
 - `first_name`
@@ -132,7 +132,7 @@
 - `created_at`
 - `updated_at`
 
-### 11. DelegateParentLink
+### 11. DelegateParentLink *(Not Implemented)*
 - `id` (PK)
 - `delegate_id` (FK → Delegate)
 - `parent_id` (FK → Parent)
@@ -142,7 +142,7 @@
 
 ---
 
-### 12. Position
+### 12. Position *(Not Implemented)*
 - `id` (PK)
 - `program_id` (FK → Program)
 - `name` (e.g., Mayor, Governor, Councilmember)
@@ -156,7 +156,7 @@
 
 ---
 
-### 13. ProgramYearPosition
+### 13. ProgramYearPosition *(Not Implemented)*
 - `id` (PK)
 - `program_year_id` (FK → ProgramYear)
 - `position_id` (FK → Position)
@@ -171,7 +171,7 @@
 
 ---
 
-### 14. Election (if needed)
+### 14. Election (if needed) *(Not Implemented)*
 - `id` (PK)
 - `program_year_id` (FK → ProgramYear)
 - `position_id` (FK → ProgramYearPosition)
@@ -184,7 +184,7 @@
 
 ---
 
-### 15. ElectionVote
+### 15. ElectionVote *(Not Implemented)*
 - `id` (PK)
 - `election_id` (FK → Election)
 - `voter_delegate_id` (FK → Delegate)
@@ -201,80 +201,80 @@
 ---
 
 ### Program Management
-- `GET /programs` — List all programs
-- `POST /programs` — Create program
-- `GET /programs/{id}` — Get program details
-- `PUT /programs/{id}` — Update program
-- `DELETE /programs/{id}` — Retire program
+- `GET /programs` — List all programs *(not implemented)*
+- `POST /programs` — Create program *(implemented)*
+- `GET /programs/{id}` — Get program details *(not implemented)*
+- `PUT /programs/{id}` — Update program *(not implemented)*
+- `DELETE /programs/{id}` — Retire program *(not implemented)*
 
 ### Program Year Management
-- `GET /programs/{id}/years` — List years for a program
-- `POST /programs/{id}/years` — Create new program year
-- `GET /program-years/{id}` — Get year details
-- `PUT /program-years/{id}` — Update year
-- `DELETE /program-years/{id}` — Archive year
+- `GET /programs/{id}/years` — List years for a program *(implemented)*
+- `POST /programs/{id}/years` — Create new program year *(implemented)*
+- `GET /program-years/{id}` — Get year details *(implemented)*
+- `PUT /program-years/{id}` — Update year *(implemented)*
+- `DELETE /program-years/{id}` — Archive year *(implemented)*
 
 ### Grouping Types (custom naming)
-- `GET /programs/{id}/grouping-types` — List grouping types
-- `POST /programs/{id}/grouping-types` — Add grouping type
-- `PUT /grouping-types/{id}` — Update custom/plural names
-- `DELETE /grouping-types/{id}` — Retire type
+- `GET /programs/{id}/grouping-types` — List grouping types *(implemented)*
+- `POST /programs/{id}/grouping-types` — Add grouping type *(implemented)*
+- `PUT /grouping-types/{id}` — Update custom/plural names *(implemented)*
+- `DELETE /grouping-types/{id}` — Retire type *(implemented)*
 
 ### Groupings (instances: parishes, towns, etc.)
-- `GET /programs/{id}/groupings` — List all groupings
-- `POST /programs/{id}/groupings` — Add grouping
-- `PUT /groupings/{id}` — Update grouping
-- `DELETE /groupings/{id}` — Retire grouping
-- `POST /program-years/{id}/groupings/activate` — Activate groupings for year
-- `GET /program-years/{id}/groupings` — List active groupings for year
+- `GET /programs/{id}/groupings` — List all groupings *(implemented)*
+- `POST /programs/{id}/groupings` — Add grouping *(implemented)*
+- `PUT /groupings/{id}` — Update grouping *(implemented)*
+- `DELETE /groupings/{id}` — Retire grouping *(implemented)*
+- `POST /program-years/{id}/groupings/activate` — Activate groupings for year *(implemented)*
+- `GET /program-years/{id}/groupings` — List active groupings for year *(implemented)*
 
 ### Parties
-- `GET /programs/{id}/parties`
-- `POST /programs/{id}/parties`
-- `PUT /parties/{id}`
-- `DELETE /parties/{id}`
-- `POST /program-years/{id}/parties/activate`
-- `GET /program-years/{id}/parties`
+- `GET /programs/{id}/parties` *(not implemented)*
+- `POST /programs/{id}/parties` *(not implemented)*
+- `PUT /parties/{id}` *(not implemented)*
+- `DELETE /parties/{id}` *(not implemented)*
+- `POST /program-years/{id}/parties/activate` *(not implemented)*
+- `GET /program-years/{id}/parties` *(not implemented)*
 
 ### Delegates
-- `GET /program-years/{id}/delegates`
-- `POST /program-years/{id}/delegates`
-- `PUT /delegates/{id}`
-- `DELETE /delegates/{id}`
+- `GET /program-years/{id}/delegates` *(not implemented)*
+- `POST /program-years/{id}/delegates` *(not implemented)*
+- `PUT /delegates/{id}` *(not implemented)*
+- `DELETE /delegates/{id}` *(not implemented)*
 
 ### Staff
-- `GET /program-years/{id}/staff`
-- `POST /program-years/{id}/staff`
-- `PUT /staff/{id}`
-- `DELETE /staff/{id}`
+- `GET /program-years/{id}/staff` *(not implemented)*
+- `POST /program-years/{id}/staff` *(not implemented)*
+- `PUT /staff/{id}` *(not implemented)*
+- `DELETE /staff/{id}` *(not implemented)*
 
 ### Parents & Delegate Linking
-- `GET /program-years/{id}/parents`
-- `POST /program-years/{id}/parents`
-- `PUT /parents/{id}`
-- `DELETE /parents/{id}`
-- `POST /delegate-parent-links` (create link)
-- `PUT /delegate-parent-links/{id}` (update status)
+- `GET /program-years/{id}/parents` *(not implemented)*
+- `POST /program-years/{id}/parents` *(not implemented)*
+- `PUT /parents/{id}` *(not implemented)*
+- `DELETE /parents/{id}` *(not implemented)*
+- `POST /delegate-parent-links` (create link) *(not implemented)*
+- `PUT /delegate-parent-links/{id}` (update status) *(not implemented)*
 
 ### Positions
-- `GET /programs/{id}/positions`
-- `POST /programs/{id}/positions`
-- `PUT /positions/{id}`
-- `DELETE /positions/{id}`
+- `GET /programs/{id}/positions` *(not implemented)*
+- `POST /programs/{id}/positions` *(not implemented)*
+- `PUT /positions/{id}` *(not implemented)*
+- `DELETE /positions/{id}` *(not implemented)*
 
 ### Program Year Positions (instances/assignments)
-- `GET /program-years/{id}/positions`
-- `POST /program-years/{id}/positions`
-- `PUT /program-year-positions/{id}`
-- `DELETE /program-year-positions/{id}`
+- `GET /program-years/{id}/positions` *(not implemented)*
+- `POST /program-years/{id}/positions` *(not implemented)*
+- `PUT /program-year-positions/{id}` *(not implemented)*
+- `DELETE /program-year-positions/{id}` *(not implemented)*
 
 ### Elections (if implemented)
-- `GET /program-years/{id}/elections`
-- `POST /program-years/{id}/elections`
-- `PUT /elections/{id}`
-- `DELETE /elections/{id}`
-- `POST /elections/{id}/vote` (submit vote)
-- `GET /elections/{id}/results`
+- `GET /program-years/{id}/elections` *(not implemented)*
+- `POST /program-years/{id}/elections` *(not implemented)*
+- `PUT /elections/{id}` *(not implemented)*
+- `DELETE /elections/{id}` *(not implemented)*
+- `POST /elections/{id}/vote` (submit vote) *(not implemented)*
+- `GET /elections/{id}/results` *(not implemented)*
 
 ### Other (as needed: notifications, resources, schedule, etc.)
 

--- a/__tests__/groupings.test.ts
+++ b/__tests__/groupings.test.ts
@@ -1,0 +1,91 @@
+import request from 'supertest';
+jest.mock('../src/prisma');
+import prisma from '../src/prisma';
+import app from '../src/index';
+import { sign } from '../src/jwt';
+
+const mockedPrisma = prisma as any;
+const token = sign({ userId: 1, email: 'admin@example.com' }, 'development-secret');
+
+beforeEach(() => {
+  mockedPrisma.programAssignment.findFirst.mockReset();
+  mockedPrisma.grouping.create.mockReset();
+  mockedPrisma.grouping.findMany.mockReset();
+  mockedPrisma.grouping.findUnique.mockReset();
+  mockedPrisma.grouping.update.mockReset();
+  mockedPrisma.programYear.findUnique.mockReset();
+  mockedPrisma.programYearGrouping.create.mockReset();
+  mockedPrisma.programYearGrouping.findMany.mockReset();
+});
+
+describe('Grouping endpoints', () => {
+  it('creates grouping when admin', async () => {
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'admin' });
+    mockedPrisma.grouping.create.mockResolvedValueOnce({ id: 1, programId: 'abc', name: 'Town 1' });
+    const res = await request(app)
+      .post('/programs/abc/groupings')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ groupingTypeId: 1, name: 'Town 1' });
+    expect(res.status).toBe(201);
+    expect(mockedPrisma.grouping.create).toHaveBeenCalled();
+  });
+
+  it('lists groupings for member', async () => {
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'delegate' });
+    mockedPrisma.grouping.findMany.mockResolvedValueOnce([{ id: 1, programId: 'abc', name: 'Town 1' }]);
+    const res = await request(app)
+      .get('/programs/abc/groupings')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body.length).toBe(1);
+  });
+
+  it('updates grouping when admin', async () => {
+    mockedPrisma.grouping.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc' });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'admin' });
+    mockedPrisma.grouping.update.mockResolvedValueOnce({ id: 1, programId: 'abc', name: 'Updated' });
+    const res = await request(app)
+      .put('/groupings/1')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'Updated' });
+    expect(res.status).toBe(200);
+    expect(mockedPrisma.grouping.update).toHaveBeenCalled();
+  });
+
+  it('retires grouping', async () => {
+    mockedPrisma.grouping.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc' });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'admin' });
+    mockedPrisma.grouping.update.mockResolvedValueOnce({ id: 1, programId: 'abc', status: 'retired' });
+    const res = await request(app)
+      .delete('/groupings/1')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(mockedPrisma.grouping.update).toHaveBeenCalledWith({
+      where: { id: 1 },
+      data: { status: 'retired' },
+    });
+  });
+
+  it('activates groupings for a program year', async () => {
+    mockedPrisma.programYear.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc', year: 2025 });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'admin' });
+    mockedPrisma.programYearGrouping.create.mockResolvedValueOnce({ id: 1 });
+    const res = await request(app)
+      .post('/program-years/1/groupings/activate')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ groupingIds: [1] });
+    expect(res.status).toBe(201);
+    expect(mockedPrisma.programYearGrouping.create).toHaveBeenCalled();
+  });
+
+  it('lists program year groupings for member', async () => {
+    mockedPrisma.programYear.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc', year: 2025 });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'delegate' });
+    mockedPrisma.programYearGrouping.findMany.mockResolvedValueOnce([{ id: 1, groupingId: 1 }]);
+    const res = await request(app)
+      .get('/program-years/1/groupings')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body.length).toBe(1);
+  });
+});

--- a/dist/openapi.yaml
+++ b/dist/openapi.yaml
@@ -16,6 +16,8 @@ tags:
     description: User registration and login
   - name: groupingTypes
     description: Manage grouping type definitions
+  - name: groupings
+    description: Manage program groupings
 
 paths:
   /health:
@@ -628,6 +630,181 @@ paths:
       responses:
         '200':
           description: Retired grouping type
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+      security:
+        - bearerAuth: []
+  /programs/{programId}/groupings:
+    post:
+      tags: [groupings]
+      summary: Add grouping
+      parameters:
+        - in: path
+          name: programId
+          required: true
+          schema:
+            type: string
+          description: Program ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [groupingTypeId, name]
+              properties:
+                groupingTypeId:
+                  type: integer
+                parentGroupingId:
+                  type: integer
+                name:
+                  type: string
+                displayOrder:
+                  type: integer
+                notes:
+                  type: string
+      responses:
+        '201':
+          description: Created grouping
+        '400':
+          description: Invalid input
+        '403':
+          description: Forbidden
+      security:
+        - bearerAuth: []
+    get:
+      tags: [groupings]
+      summary: List groupings
+      parameters:
+        - in: path
+          name: programId
+          required: true
+          schema:
+            type: string
+          description: Program ID
+      responses:
+        '200':
+          description: Array of groupings
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+        '403':
+          description: Forbidden
+      security:
+        - bearerAuth: []
+  /groupings/{id}:
+    put:
+      tags: [groupings]
+      summary: Update grouping
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                displayOrder:
+                  type: integer
+                notes:
+                  type: string
+                parentGroupingId:
+                  type: integer
+                status:
+                  type: string
+      responses:
+        '200':
+          description: Updated grouping
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+      security:
+        - bearerAuth: []
+    delete:
+      tags: [groupings]
+      summary: Retire grouping
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Retired grouping
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+      security:
+        - bearerAuth: []
+  /program-years/{id}/groupings/activate:
+    post:
+      tags: [groupings]
+      summary: Activate groupings for year
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+          description: Program Year ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [groupingIds]
+              properties:
+                groupingIds:
+                  type: array
+                  items:
+                    type: integer
+      responses:
+        '201':
+          description: Activated groupings
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+        '400':
+          description: Invalid input
+      security:
+        - bearerAuth: []
+  /program-years/{id}/groupings:
+    get:
+      tags: [groupings]
+      summary: List active groupings for year
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+          description: Program Year ID
+      responses:
+        '200':
+          description: Array of active groupings
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
         '403':
           description: Forbidden
         '404':

--- a/src/__mocks__/prisma.ts
+++ b/src/__mocks__/prisma.ts
@@ -24,6 +24,16 @@ const prisma = {
     findUnique: jest.fn(),
     update: jest.fn(),
   },
+  grouping: {
+    create: jest.fn(),
+    findMany: jest.fn(),
+    findUnique: jest.fn(),
+    update: jest.fn(),
+  },
+  programYearGrouping: {
+    create: jest.fn(),
+    findMany: jest.fn(),
+  },
   log: {
     create: jest.fn().mockResolvedValue(null),
     findMany: jest.fn(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -650,6 +650,161 @@ app.delete('/grouping-types/:id', async (req: express.Request, res: express.Resp
   res.json(updated);
 });
 
+app.post('/programs/:programId/groupings', async (req: express.Request, res: express.Response) => {
+  const { programId } = req.params as { programId?: string };
+  const caller = (req as any).user as { userId: number; email: string };
+  if (!programId) {
+    res.status(400).json({ error: 'programId required' });
+    return;
+  }
+  const isAdmin = await isProgramAdmin(caller.userId, programId);
+  if (!isAdmin) {
+    res.status(403).json({ error: 'Forbidden' });
+    return;
+  }
+  const { groupingTypeId, parentGroupingId, name, displayOrder, notes } = req.body as {
+    groupingTypeId?: number;
+    parentGroupingId?: number;
+    name?: string;
+    displayOrder?: number;
+    notes?: string;
+  };
+  if (!groupingTypeId || !name) {
+    res.status(400).json({ error: 'groupingTypeId and name required' });
+    return;
+  }
+  const grouping = await prisma.grouping.create({
+    data: {
+      programId,
+      groupingTypeId,
+      parentGroupingId,
+      name,
+      displayOrder,
+      notes,
+      status: 'active',
+    },
+  });
+  logger.info(programId, `Grouping ${grouping.id} created`);
+  res.status(201).json(grouping);
+});
+
+app.get('/programs/:programId/groupings', async (req: express.Request, res: express.Response) => {
+  const { programId } = req.params as { programId?: string };
+  const caller = (req as any).user as { userId: number };
+  if (!programId) {
+    res.status(400).json({ error: 'programId required' });
+    return;
+  }
+  const isMember = await isProgramMember(caller.userId, programId);
+  if (!isMember) {
+    res.status(403).json({ error: 'Forbidden' });
+    return;
+  }
+  const groupings = await prisma.grouping.findMany({
+    where: { programId },
+    orderBy: { displayOrder: 'asc' },
+  });
+  res.json(groupings);
+});
+
+app.put('/groupings/:id', async (req: express.Request, res: express.Response) => {
+  const { id } = req.params as { id?: string };
+  const caller = (req as any).user as { userId: number };
+  const grouping = await prisma.grouping.findUnique({ where: { id: Number(id) } });
+  if (!grouping) {
+    res.status(404).json({ error: 'Not found' });
+    return;
+  }
+  const isAdmin = await isProgramAdmin(caller.userId, grouping.programId);
+  if (!isAdmin) {
+    res.status(403).json({ error: 'Forbidden' });
+    return;
+  }
+  const { name, displayOrder, notes, parentGroupingId, status } = req.body as {
+    name?: string;
+    displayOrder?: number;
+    notes?: string;
+    parentGroupingId?: number;
+    status?: string;
+  };
+  const updated = await prisma.grouping.update({
+    where: { id: Number(id) },
+    data: { name, displayOrder, notes, parentGroupingId, status },
+  });
+  logger.info(grouping.programId, `Grouping ${grouping.id} updated`);
+  res.json(updated);
+});
+
+app.delete('/groupings/:id', async (req: express.Request, res: express.Response) => {
+  const { id } = req.params as { id?: string };
+  const caller = (req as any).user as { userId: number };
+  const grouping = await prisma.grouping.findUnique({ where: { id: Number(id) } });
+  if (!grouping) {
+    res.status(404).json({ error: 'Not found' });
+    return;
+  }
+  const isAdmin = await isProgramAdmin(caller.userId, grouping.programId);
+  if (!isAdmin) {
+    res.status(403).json({ error: 'Forbidden' });
+    return;
+  }
+  const updated = await prisma.grouping.update({
+    where: { id: Number(id) },
+    data: { status: 'retired' },
+  });
+  logger.info(grouping.programId, `Grouping ${grouping.id} retired`);
+  res.json(updated);
+});
+
+app.post('/program-years/:id/groupings/activate', async (req: express.Request, res: express.Response) => {
+  const { id } = req.params as { id?: string };
+  const caller = (req as any).user as { userId: number };
+  const py = await prisma.programYear.findUnique({ where: { id: Number(id) } });
+  if (!py) {
+    res.status(404).json({ error: 'Not found' });
+    return;
+  }
+  const isAdmin = await isProgramAdmin(caller.userId, py.programId);
+  if (!isAdmin) {
+    res.status(403).json({ error: 'Forbidden' });
+    return;
+  }
+  const { groupingIds } = req.body as { groupingIds?: number[] };
+  if (!Array.isArray(groupingIds) || groupingIds.length === 0) {
+    res.status(400).json({ error: 'groupingIds required' });
+    return;
+  }
+  const records = await Promise.all(
+    groupingIds.map((gid) =>
+      prisma.programYearGrouping.create({
+        data: { programYearId: py.id, groupingId: gid, status: 'active' },
+      })
+    )
+  );
+  logger.info(py.programId, `Activated ${records.length} groupings for PY ${py.year}`);
+  res.status(201).json(records);
+});
+
+app.get('/program-years/:id/groupings', async (req: express.Request, res: express.Response) => {
+  const { id } = req.params as { id?: string };
+  const caller = (req as any).user as { userId: number };
+  const py = await prisma.programYear.findUnique({ where: { id: Number(id) } });
+  if (!py) {
+    res.status(404).json({ error: 'Not found' });
+    return;
+  }
+  const isMember = await isProgramMember(caller.userId, py.programId);
+  if (!isMember) {
+    res.status(403).json({ error: 'Forbidden' });
+    return;
+  }
+  const records = await prisma.programYearGrouping.findMany({
+    where: { programYearId: py.id, status: 'active' },
+    include: { grouping: true },
+  });
+  res.json(records);
+});
+
 if (process.env.NODE_ENV !== 'test') {
   ensureDatabase();
   app.listen(port, () => {

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -16,6 +16,8 @@ tags:
     description: User registration and login
   - name: groupingTypes
     description: Manage grouping type definitions
+  - name: groupings
+    description: Manage program groupings
 
 paths:
   /health:
@@ -628,6 +630,181 @@ paths:
       responses:
         '200':
           description: Retired grouping type
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+      security:
+        - bearerAuth: []
+  /programs/{programId}/groupings:
+    post:
+      tags: [groupings]
+      summary: Add grouping
+      parameters:
+        - in: path
+          name: programId
+          required: true
+          schema:
+            type: string
+          description: Program ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [groupingTypeId, name]
+              properties:
+                groupingTypeId:
+                  type: integer
+                parentGroupingId:
+                  type: integer
+                name:
+                  type: string
+                displayOrder:
+                  type: integer
+                notes:
+                  type: string
+      responses:
+        '201':
+          description: Created grouping
+        '400':
+          description: Invalid input
+        '403':
+          description: Forbidden
+      security:
+        - bearerAuth: []
+    get:
+      tags: [groupings]
+      summary: List groupings
+      parameters:
+        - in: path
+          name: programId
+          required: true
+          schema:
+            type: string
+          description: Program ID
+      responses:
+        '200':
+          description: Array of groupings
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+        '403':
+          description: Forbidden
+      security:
+        - bearerAuth: []
+  /groupings/{id}:
+    put:
+      tags: [groupings]
+      summary: Update grouping
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                displayOrder:
+                  type: integer
+                notes:
+                  type: string
+                parentGroupingId:
+                  type: integer
+                status:
+                  type: string
+      responses:
+        '200':
+          description: Updated grouping
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+      security:
+        - bearerAuth: []
+    delete:
+      tags: [groupings]
+      summary: Retire grouping
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Retired grouping
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+      security:
+        - bearerAuth: []
+  /program-years/{id}/groupings/activate:
+    post:
+      tags: [groupings]
+      summary: Activate groupings for year
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+          description: Program Year ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [groupingIds]
+              properties:
+                groupingIds:
+                  type: array
+                  items:
+                    type: integer
+      responses:
+        '201':
+          description: Activated groupings
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+        '400':
+          description: Invalid input
+      security:
+        - bearerAuth: []
+  /program-years/{id}/groupings:
+    get:
+      tags: [groupings]
+      summary: List active groupings for year
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+          description: Program Year ID
+      responses:
+        '200':
+          description: Array of active groupings
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
         '403':
           description: Forbidden
         '404':


### PR DESCRIPTION
## Summary
- mark implemented vs planned features in ProgramConfigSpec
- add REST endpoints for program groupings
- document groupings in OpenAPI spec
- update Prisma mock and add unit tests

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_686aa1c2c00c832d920ea97326025adb