### PR TITLE
Implement staff management endpoints

### DIFF
--- a/ProgramConfigSpec.md
+++ b/ProgramConfigSpec.md
@@ -107,7 +107,7 @@
 
 ---
 
-### 9. Staff *(Not Implemented)*
+### 9. Staff *(Implemented)*
 - `id` (PK)
 - `program_year_id` (FK → ProgramYear)
 - `first_name`
@@ -243,10 +243,10 @@
 - `DELETE /delegates/{id}` *(implemented)*
 
 ### Staff
-- `GET /program-years/{id}/staff` *(not implemented)*
-- `POST /program-years/{id}/staff` *(not implemented)*
-- `PUT /staff/{id}` *(not implemented)*
-- `DELETE /staff/{id}` *(not implemented)*
+- `GET /program-years/{id}/staff` *(implemented)*
+- `POST /program-years/{id}/staff` *(implemented)*
+- `PUT /staff/{id}` *(implemented)*
+- `DELETE /staff/{id}` *(implemented)*
 
 ### Parents & Delegate Linking
 - `GET /program-years/{id}/parents` *(not implemented)*

--- a/__tests__/staff.test.ts
+++ b/__tests__/staff.test.ts
@@ -1,0 +1,67 @@
+import request from 'supertest';
+jest.mock('../src/prisma');
+import prisma from '../src/prisma';
+import app from '../src/index';
+import { sign } from '../src/jwt';
+
+const mockedPrisma = prisma as any;
+const token = sign({ userId: 1, email: 'admin@example.com' }, 'development-secret');
+
+beforeEach(() => {
+  mockedPrisma.programAssignment.findFirst.mockReset();
+  mockedPrisma.programYear.findUnique.mockReset();
+  mockedPrisma.staff.create.mockReset();
+  mockedPrisma.staff.findMany.mockReset();
+  mockedPrisma.staff.findUnique.mockReset();
+  mockedPrisma.staff.update.mockReset();
+});
+
+describe('Staff endpoints', () => {
+  it('creates staff when admin', async () => {
+    mockedPrisma.programYear.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc', year: 2025 });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'admin' });
+    mockedPrisma.staff.create.mockResolvedValueOnce({ id: 1, programYearId: 1, firstName: 'Jane' });
+    const res = await request(app)
+      .post('/program-years/1/staff')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ firstName: 'Jane', lastName: 'Doe', email: 'jd@example.com', role: 'counselor' });
+    expect(res.status).toBe(201);
+    expect(mockedPrisma.staff.create).toHaveBeenCalled();
+  });
+
+  it('lists staff for member', async () => {
+    mockedPrisma.programYear.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc', year: 2025 });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'delegate' });
+    mockedPrisma.staff.findMany.mockResolvedValueOnce([{ id: 1 }]);
+    const res = await request(app)
+      .get('/program-years/1/staff')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body.length).toBe(1);
+  });
+
+  it('updates staff when admin', async () => {
+    mockedPrisma.staff.findUnique.mockResolvedValueOnce({ id: 1, programYearId: 1 });
+    mockedPrisma.programYear.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc' });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'admin' });
+    mockedPrisma.staff.update.mockResolvedValueOnce({ id: 1, firstName: 'Janet' });
+    const res = await request(app)
+      .put('/staff/1')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ firstName: 'Janet' });
+    expect(res.status).toBe(200);
+    expect(mockedPrisma.staff.update).toHaveBeenCalled();
+  });
+
+  it('removes staff', async () => {
+    mockedPrisma.staff.findUnique.mockResolvedValueOnce({ id: 1, programYearId: 1 });
+    mockedPrisma.programYear.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc' });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'admin' });
+    mockedPrisma.staff.update.mockResolvedValueOnce({ id: 1, status: 'inactive' });
+    const res = await request(app)
+      .delete('/staff/1')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(mockedPrisma.staff.update).toHaveBeenCalledWith({ where: { id: 1 }, data: { status: 'inactive' } });
+  });
+});

--- a/dist/openapi.yaml
+++ b/dist/openapi.yaml
@@ -22,6 +22,8 @@ tags:
     description: Manage program parties
   - name: delegates
     description: Manage program delegates
+  - name: staff
+    description: Manage program staff
 
 paths:
   /health:
@@ -1193,6 +1195,135 @@ paths:
       responses:
         '200':
           description: Delegate withdrawn
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+      security:
+        - bearerAuth: []
+  /program-years/{id}/staff:
+    post:
+      tags: [staff]
+      summary: Add staff member
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+          description: Program Year ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [firstName, lastName, email, role]
+              properties:
+                firstName:
+                  type: string
+                lastName:
+                  type: string
+                email:
+                  type: string
+                phone:
+                  type: string
+                userId:
+                  type: integer
+                role:
+                  type: string
+                groupingId:
+                  type: integer
+      responses:
+        '201':
+          description: Staff created
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+        '400':
+          description: Invalid input
+      security:
+        - bearerAuth: []
+    get:
+      tags: [staff]
+      summary: List staff for year
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+          description: Program Year ID
+      responses:
+        '200':
+          description: Array of staff
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+      security:
+        - bearerAuth: []
+  /staff/{id}:
+    put:
+      tags: [staff]
+      summary: Update staff member
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                firstName:
+                  type: string
+                lastName:
+                  type: string
+                email:
+                  type: string
+                phone:
+                  type: string
+                userId:
+                  type: integer
+                role:
+                  type: string
+                groupingId:
+                  type: integer
+                status:
+                  type: string
+      responses:
+        '200':
+          description: Updated staff member
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+      security:
+        - bearerAuth: []
+    delete:
+      tags: [staff]
+      summary: Remove staff member
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Staff removed
         '403':
           description: Forbidden
         '404':

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,28 +14,28 @@ datasource db {
 }
 
 model User {
-  id        Int      @id @default(autoincrement())
-  email     String   @unique
-  password  String
-  createdAt DateTime @default(now())
-  programs  ProgramAssignment[]
-  createdPrograms Program[] @relation("ProgramCreatedBy")
+  id              Int                 @id @default(autoincrement())
+  email           String              @unique
+  password        String
+  createdAt       DateTime            @default(now())
+  programs        ProgramAssignment[]
+  createdPrograms Program[]           @relation("ProgramCreatedBy")
 }
 
 model Program {
-  id          String             @id @default(cuid())
-  name        String
-  year        Int
-  config      Json?
-  createdBy   User               @relation("ProgramCreatedBy", fields: [createdById], references: [id])
-  createdById Int
-  assignments ProgramAssignment[]
-  years       ProgramYear[]
+  id            String              @id @default(cuid())
+  name          String
+  year          Int
+  config        Json?
+  createdBy     User                @relation("ProgramCreatedBy", fields: [createdById], references: [id])
+  createdById   Int
+  assignments   ProgramAssignment[]
+  years         ProgramYear[]
   groupingTypes GroupingType[]
-  groupings   Grouping[]
-  parties     Party[]
-  status      String   @default("active")
-  createdAt   DateTime           @default(now())
+  groupings     Grouping[]
+  parties       Party[]
+  status        String              @default("active")
+  createdAt     DateTime            @default(now())
 }
 
 model ProgramAssignment {
@@ -59,55 +59,57 @@ model Log {
 }
 
 model ProgramYear {
-  id        Int      @id @default(autoincrement())
-  program   Program  @relation(fields: [programId], references: [id])
+  id        Int                   @id @default(autoincrement())
+  program   Program               @relation(fields: [programId], references: [id])
   programId String
   year      Int
   startDate DateTime?
   endDate   DateTime?
-  status    String   @default("active")
+  status    String                @default("active")
   notes     String?
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  createdAt DateTime              @default(now())
+  updatedAt DateTime              @updatedAt
   groupings ProgramYearGrouping[]
   parties   ProgramYearParty[]
   delegates Delegate[]
+  staff     Staff[]
 }
 
 model GroupingType {
-  id          Int      @id @default(autoincrement())
-  program     Program  @relation(fields: [programId], references: [id])
+  id          Int        @id @default(autoincrement())
+  program     Program    @relation(fields: [programId], references: [id])
   programId   String
   defaultName String
   customName  String?
   pluralName  String?
   levelOrder  Int
-  isRequired  Boolean  @default(false)
-  status      String   @default("active")
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  isRequired  Boolean    @default(false)
+  status      String     @default("active")
+  createdAt   DateTime   @default(now())
+  updatedAt   DateTime   @updatedAt
   groupings   Grouping[]
 
   @@index([programId])
 }
 
 model Grouping {
-  id              Int       @id @default(autoincrement())
-  program         Program   @relation(fields: [programId], references: [id])
-  programId       String
-  groupingType    GroupingType @relation(fields: [groupingTypeId], references: [id])
-  groupingTypeId  Int
-  parentGrouping  Grouping? @relation("GroupingToParent", fields: [parentGroupingId], references: [id])
+  id               Int                   @id @default(autoincrement())
+  program          Program               @relation(fields: [programId], references: [id])
+  programId        String
+  groupingType     GroupingType          @relation(fields: [groupingTypeId], references: [id])
+  groupingTypeId   Int
+  parentGrouping   Grouping?             @relation("GroupingToParent", fields: [parentGroupingId], references: [id])
   parentGroupingId Int?
-  children        Grouping[] @relation("GroupingToParent")
-  name            String
-  status          String   @default("active")
-  displayOrder    Int?
-  notes           String?
-  createdAt       DateTime @default(now())
-  updatedAt       DateTime @updatedAt
-  programYears    ProgramYearGrouping[]
-  delegates       Delegate[]
+  children         Grouping[]            @relation("GroupingToParent")
+  name             String
+  status           String                @default("active")
+  displayOrder     Int?
+  notes            String?
+  createdAt        DateTime              @default(now())
+  updatedAt        DateTime              @updatedAt
+  programYears     ProgramYearGrouping[]
+  delegates        Delegate[]
+  staff            Staff[]
 
   @@index([programId])
   @@index([groupingTypeId])
@@ -127,17 +129,17 @@ model ProgramYearGrouping {
 }
 
 model Party {
-  id           Int      @id @default(autoincrement())
-  program      Program  @relation(fields: [programId], references: [id])
-  programId    String
-  name         String
-  abbreviation String?
-  color        String?
-  icon         String?
-  status       String   @default("active")
-  displayOrder Int?
-  createdAt    DateTime @default(now())
-  updatedAt    DateTime @updatedAt
+  id                 Int                @id @default(autoincrement())
+  program            Program            @relation(fields: [programId], references: [id])
+  programId          String
+  name               String
+  abbreviation       String?
+  color              String?
+  icon               String?
+  status             String             @default("active")
+  displayOrder       Int?
+  createdAt          DateTime           @default(now())
+  updatedAt          DateTime           @updatedAt
   programYearParties ProgramYearParty[]
 
   @@index([programId])
@@ -157,24 +159,43 @@ model ProgramYearParty {
 }
 
 model Delegate {
-  id             Int             @id @default(autoincrement())
-  programYear    ProgramYear     @relation(fields: [programYearId], references: [id])
-  programYearId  Int
-  firstName      String
-  lastName       String
-  email          String
-  phone          String?
-  userId         Int?
-  grouping       Grouping        @relation(fields: [groupingId], references: [id])
-  groupingId     Int
-  party          ProgramYearParty? @relation(fields: [partyId], references: [id])
-  partyId        Int?
-  status         String          @default("active")
-  createdAt      DateTime        @default(now())
-  updatedAt      DateTime        @updatedAt
+  id            Int               @id @default(autoincrement())
+  programYear   ProgramYear       @relation(fields: [programYearId], references: [id])
+  programYearId Int
+  firstName     String
+  lastName      String
+  email         String
+  phone         String?
+  userId        Int?
+  grouping      Grouping          @relation(fields: [groupingId], references: [id])
+  groupingId    Int
+  party         ProgramYearParty? @relation(fields: [partyId], references: [id])
+  partyId       Int?
+  status        String            @default("active")
+  createdAt     DateTime          @default(now())
+  updatedAt     DateTime          @updatedAt
 
   @@index([programYearId])
   @@index([groupingId])
   @@index([partyId])
 }
 
+model Staff {
+  id            Int         @id @default(autoincrement())
+  programYear   ProgramYear @relation(fields: [programYearId], references: [id])
+  programYearId Int
+  firstName     String
+  lastName      String
+  email         String
+  phone         String?
+  userId        Int?
+  role          String
+  grouping      Grouping?   @relation(fields: [groupingId], references: [id])
+  groupingId    Int?
+  status        String      @default("active")
+  createdAt     DateTime    @default(now())
+  updatedAt     DateTime    @updatedAt
+
+  @@index([programYearId])
+  @@index([groupingId])
+}

--- a/src/__mocks__/prisma.ts
+++ b/src/__mocks__/prisma.ts
@@ -53,6 +53,12 @@ const prisma = {
     findUnique: jest.fn(),
     update: jest.fn(),
   },
+  staff: {
+    create: jest.fn(),
+    findMany: jest.fn(),
+    findUnique: jest.fn(),
+    update: jest.fn(),
+  },
   log: {
     create: jest.fn().mockResolvedValue(null),
     findMany: jest.fn(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -1145,6 +1145,125 @@ app.delete('/delegates/:id', async (req: express.Request, res: express.Response)
   res.json(updated);
 });
 
+app.post('/program-years/:id/staff', async (req: express.Request, res: express.Response) => {
+  const { id } = req.params as { id?: string };
+  const caller = (req as any).user as { userId: number };
+  const py = await prisma.programYear.findUnique({ where: { id: Number(id) } });
+  if (!py) {
+    res.status(404).json({ error: 'Not found' });
+    return;
+  }
+  const isAdmin = await isProgramAdmin(caller.userId, py.programId);
+  if (!isAdmin) {
+    res.status(403).json({ error: 'Forbidden' });
+    return;
+  }
+  const { firstName, lastName, email, phone, userId, role, groupingId } = req.body as {
+    firstName?: string;
+    lastName?: string;
+    email?: string;
+    phone?: string;
+    userId?: number;
+    role?: string;
+    groupingId?: number;
+  };
+  if (!firstName || !lastName || !email || !role) {
+    res.status(400).json({ error: 'firstName, lastName, email and role required' });
+    return;
+  }
+  const staff = await prisma.staff.create({
+    data: {
+      programYearId: py.id,
+      firstName,
+      lastName,
+      email,
+      phone,
+      userId,
+      role,
+      groupingId,
+      status: 'active',
+    },
+  });
+  logger.info(py.programId, `Staff ${staff.id} created`);
+  res.status(201).json(staff);
+});
+
+app.get('/program-years/:id/staff', async (req: express.Request, res: express.Response) => {
+  const { id } = req.params as { id?: string };
+  const caller = (req as any).user as { userId: number };
+  const py = await prisma.programYear.findUnique({ where: { id: Number(id) } });
+  if (!py) {
+    res.status(404).json({ error: 'Not found' });
+    return;
+  }
+  const isMember = await isProgramMember(caller.userId, py.programId);
+  if (!isMember) {
+    res.status(403).json({ error: 'Forbidden' });
+    return;
+  }
+  const staffList = await prisma.staff.findMany({ where: { programYearId: py.id } });
+  res.json(staffList);
+});
+
+app.put('/staff/:id', async (req: express.Request, res: express.Response) => {
+  const { id } = req.params as { id?: string };
+  const caller = (req as any).user as { userId: number };
+  const staff = await prisma.staff.findUnique({ where: { id: Number(id) } });
+  if (!staff) {
+    res.status(404).json({ error: 'Not found' });
+    return;
+  }
+  const py = await prisma.programYear.findUnique({ where: { id: staff.programYearId } });
+  if (!py) {
+    res.status(404).json({ error: 'Not found' });
+    return;
+  }
+  const isAdmin = await isProgramAdmin(caller.userId, py.programId);
+  if (!isAdmin) {
+    res.status(403).json({ error: 'Forbidden' });
+    return;
+  }
+  const { firstName, lastName, email, phone, userId, role, groupingId, status } = req.body as {
+    firstName?: string;
+    lastName?: string;
+    email?: string;
+    phone?: string;
+    userId?: number;
+    role?: string;
+    groupingId?: number;
+    status?: string;
+  };
+  const updated = await prisma.staff.update({
+    where: { id: Number(id) },
+    data: { firstName, lastName, email, phone, userId, role, groupingId, status },
+  });
+  logger.info(py.programId, `Staff ${staff.id} updated`);
+  res.json(updated);
+});
+
+app.delete('/staff/:id', async (req: express.Request, res: express.Response) => {
+  const { id } = req.params as { id?: string };
+  const caller = (req as any).user as { userId: number };
+  const staff = await prisma.staff.findUnique({ where: { id: Number(id) } });
+  if (!staff) {
+    res.status(404).json({ error: 'Not found' });
+    return;
+  }
+  const py = await prisma.programYear.findUnique({ where: { id: staff.programYearId } });
+  if (!py) {
+    res.status(404).json({ error: 'Not found' });
+    return;
+  }
+  const isAdmin = await isProgramAdmin(caller.userId, py.programId);
+  if (!isAdmin) {
+    res.status(403).json({ error: 'Forbidden' });
+    return;
+  }
+  const updated = await prisma.staff.update({ where: { id: Number(id) }, data: { status: 'inactive' } });
+  logger.info(py.programId, `Staff ${staff.id} removed`);
+  res.json(updated);
+});
+
 if (process.env.NODE_ENV !== 'test') {
   ensureDatabase();
   app.listen(port, () => {

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -22,6 +22,8 @@ tags:
     description: Manage program parties
   - name: delegates
     description: Manage program delegates
+  - name: staff
+    description: Manage program staff
 
 paths:
   /health:
@@ -1193,6 +1195,135 @@ paths:
       responses:
         '200':
           description: Delegate withdrawn
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+      security:
+        - bearerAuth: []
+  /program-years/{id}/staff:
+    post:
+      tags: [staff]
+      summary: Add staff member
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+          description: Program Year ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [firstName, lastName, email, role]
+              properties:
+                firstName:
+                  type: string
+                lastName:
+                  type: string
+                email:
+                  type: string
+                phone:
+                  type: string
+                userId:
+                  type: integer
+                role:
+                  type: string
+                groupingId:
+                  type: integer
+      responses:
+        '201':
+          description: Staff created
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+        '400':
+          description: Invalid input
+      security:
+        - bearerAuth: []
+    get:
+      tags: [staff]
+      summary: List staff for year
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+          description: Program Year ID
+      responses:
+        '200':
+          description: Array of staff
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+      security:
+        - bearerAuth: []
+  /staff/{id}:
+    put:
+      tags: [staff]
+      summary: Update staff member
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                firstName:
+                  type: string
+                lastName:
+                  type: string
+                email:
+                  type: string
+                phone:
+                  type: string
+                userId:
+                  type: integer
+                role:
+                  type: string
+                groupingId:
+                  type: integer
+                status:
+                  type: string
+      responses:
+        '200':
+          description: Updated staff member
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+      security:
+        - bearerAuth: []
+    delete:
+      tags: [staff]
+      summary: Remove staff member
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Staff removed
         '403':
           description: Forbidden
         '404':


### PR DESCRIPTION
## Summary
- add Staff model to Prisma schema
- implement staff CRUD endpoints
- document staff APIs in OpenAPI spec
- update mocks and add staff tests
- mark staff items implemented in ProgramConfigSpec

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_686aac4cb9f0832d8f0c06cf0a779b52