### PR TITLE
Add parent support and update spec

### DIFF
--- a/ProgramConfigSpec.md
+++ b/ProgramConfigSpec.md
@@ -122,7 +122,7 @@
 
 ---
 
-### 10. Parent *(Not Implemented)*
+### 10. Parent *(Implemented)*
 - `id` (PK)
 - `user_id` (if linked to user account)
 - `first_name`
@@ -132,7 +132,7 @@
 - `created_at`
 - `updated_at`
 
-### 11. DelegateParentLink *(Not Implemented)*
+### 11. DelegateParentLink *(Implemented)*
 - `id` (PK)
 - `delegate_id` (FK → Delegate)
 - `parent_id` (FK → Parent)
@@ -249,12 +249,12 @@
 - `DELETE /staff/{id}` *(implemented)*
 
 ### Parents & Delegate Linking
-- `GET /program-years/{id}/parents` *(not implemented)*
-- `POST /program-years/{id}/parents` *(not implemented)*
-- `PUT /parents/{id}` *(not implemented)*
-- `DELETE /parents/{id}` *(not implemented)*
-- `POST /delegate-parent-links` (create link) *(not implemented)*
-- `PUT /delegate-parent-links/{id}` (update status) *(not implemented)*
+- `GET /program-years/{id}/parents` *(implemented)*
+- `POST /program-years/{id}/parents` *(implemented)*
+- `PUT /parents/{id}` *(implemented)*
+- `DELETE /parents/{id}` *(implemented)*
+- `POST /delegate-parent-links` (create link) *(implemented)*
+- `PUT /delegate-parent-links/{id}` (update status) *(implemented)*
 
 ### Positions
 - `GET /programs/{id}/positions` *(not implemented)*

--- a/__tests__/parents.test.ts
+++ b/__tests__/parents.test.ts
@@ -1,0 +1,97 @@
+import request from 'supertest';
+jest.mock('../src/prisma');
+import prisma from '../src/prisma';
+import app from '../src/index';
+import { sign } from '../src/jwt';
+
+const mockedPrisma = prisma as any;
+const token = sign({ userId: 1, email: 'admin@example.com' }, 'development-secret');
+
+beforeEach(() => {
+  mockedPrisma.programAssignment.findFirst.mockReset();
+  mockedPrisma.programYear.findUnique.mockReset();
+  mockedPrisma.parent.create.mockReset();
+  mockedPrisma.parent.findMany.mockReset();
+  mockedPrisma.parent.findUnique.mockReset();
+  mockedPrisma.parent.update.mockReset();
+  mockedPrisma.delegateParentLink.create.mockReset();
+  mockedPrisma.delegateParentLink.findUnique.mockReset();
+  mockedPrisma.delegateParentLink.update.mockReset();
+});
+
+describe('Parent endpoints', () => {
+  it('creates parent when admin', async () => {
+    mockedPrisma.programYear.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc', year: 2025 });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'admin' });
+    mockedPrisma.parent.create.mockResolvedValueOnce({ id: 1, programYearId: 1, firstName: 'Jane' });
+    const res = await request(app)
+      .post('/program-years/1/parents')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ firstName: 'Jane', lastName: 'Doe', email: 'jd@example.com' });
+    expect(res.status).toBe(201);
+    expect(mockedPrisma.parent.create).toHaveBeenCalled();
+  });
+
+  it('lists parents for member', async () => {
+    mockedPrisma.programYear.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc', year: 2025 });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'delegate' });
+    mockedPrisma.parent.findMany.mockResolvedValueOnce([{ id: 1 }]);
+    const res = await request(app)
+      .get('/program-years/1/parents')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body.length).toBe(1);
+  });
+
+  it('updates parent when admin', async () => {
+    mockedPrisma.parent.findUnique.mockResolvedValueOnce({ id: 1, programYearId: 1 });
+    mockedPrisma.programYear.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc' });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'admin' });
+    mockedPrisma.parent.update.mockResolvedValueOnce({ id: 1, firstName: 'Janet' });
+    const res = await request(app)
+      .put('/parents/1')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ firstName: 'Janet' });
+    expect(res.status).toBe(200);
+    expect(mockedPrisma.parent.update).toHaveBeenCalled();
+  });
+
+  it('removes parent', async () => {
+    mockedPrisma.parent.findUnique.mockResolvedValueOnce({ id: 1, programYearId: 1 });
+    mockedPrisma.programYear.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc' });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'admin' });
+    mockedPrisma.parent.update.mockResolvedValueOnce({ id: 1, status: 'inactive' });
+    const res = await request(app)
+      .delete('/parents/1')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(mockedPrisma.parent.update).toHaveBeenCalledWith({ where: { id: 1 }, data: { status: 'inactive' } });
+  });
+});
+
+describe('DelegateParentLink endpoints', () => {
+  it('creates link when admin', async () => {
+    mockedPrisma.programYear.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc' });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'admin' });
+    mockedPrisma.delegateParentLink.create.mockResolvedValueOnce({ id: 1, delegateId: 2, parentId: 3 });
+    const res = await request(app)
+      .post('/delegate-parent-links')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ delegateId: 2, parentId: 3, programYearId: 1 });
+    expect(res.status).toBe(201);
+    expect(mockedPrisma.delegateParentLink.create).toHaveBeenCalled();
+  });
+
+  it('updates link when admin', async () => {
+    mockedPrisma.delegateParentLink.findUnique.mockResolvedValueOnce({ id: 1, programYearId: 1 });
+    mockedPrisma.programYear.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc' });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'admin' });
+    mockedPrisma.delegateParentLink.update.mockResolvedValueOnce({ id: 1, status: 'accepted' });
+    const res = await request(app)
+      .put('/delegate-parent-links/1')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ status: 'accepted' });
+    expect(res.status).toBe(200);
+    expect(mockedPrisma.delegateParentLink.update).toHaveBeenCalledWith({ where: { id: 1 }, data: { status: 'accepted' } });
+  });
+});

--- a/dist/openapi.yaml
+++ b/dist/openapi.yaml
@@ -1330,6 +1330,185 @@ paths:
           description: Not found
       security:
         - bearerAuth: []
+
+  /program-years/{id}/parents:
+    post:
+      tags: [parents]
+      summary: Add parent
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+          description: Program Year ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [firstName, lastName, email]
+              properties:
+                firstName:
+                  type: string
+                lastName:
+                  type: string
+                email:
+                  type: string
+                phone:
+                  type: string
+                userId:
+                  type: integer
+      responses:
+        '201':
+          description: Parent created
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+        '400':
+          description: Invalid input
+      security:
+        - bearerAuth: []
+    get:
+      tags: [parents]
+      summary: List parents for year
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+          description: Program Year ID
+      responses:
+        '200':
+          description: Array of parents
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+      security:
+        - bearerAuth: []
+  /parents/{id}:
+    put:
+      tags: [parents]
+      summary: Update parent
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                firstName:
+                  type: string
+                lastName:
+                  type: string
+                email:
+                  type: string
+                phone:
+                  type: string
+                userId:
+                  type: integer
+                status:
+                  type: string
+      responses:
+        '200':
+          description: Updated parent
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+      security:
+        - bearerAuth: []
+    delete:
+      tags: [parents]
+      summary: Remove parent
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Parent removed
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+      security:
+        - bearerAuth: []
+  /delegate-parent-links:
+    post:
+      tags: [parents]
+      summary: Create delegate-parent link
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [delegateId, parentId, programYearId]
+              properties:
+                delegateId:
+                  type: integer
+                parentId:
+                  type: integer
+                programYearId:
+                  type: integer
+      responses:
+        '201':
+          description: Link created
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+        '400':
+          description: Invalid input
+      security:
+        - bearerAuth: []
+  /delegate-parent-links/{id}:
+    put:
+      tags: [parents]
+      summary: Update delegate-parent link
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                status:
+                  type: string
+      responses:
+        '200':
+          description: Updated link
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+      security:
+        - bearerAuth: []
   /program-years/{id}:
     get:
       tags: [programs]

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -73,6 +73,8 @@ model ProgramYear {
   parties   ProgramYearParty[]
   delegates Delegate[]
   staff     Staff[]
+  parents   Parent[]
+  delegateParentLinks DelegateParentLink[]
 }
 
 model GroupingType {
@@ -174,6 +176,7 @@ model Delegate {
   status        String            @default("active")
   createdAt     DateTime          @default(now())
   updatedAt     DateTime          @updatedAt
+  parentLinks   DelegateParentLink[]
 
   @@index([programYearId])
   @@index([groupingId])
@@ -198,4 +201,37 @@ model Staff {
 
   @@index([programYearId])
   @@index([groupingId])
+}
+
+model Parent {
+  id        Int         @id @default(autoincrement())
+  programYear   ProgramYear @relation(fields: [programYearId], references: [id])
+  programYearId Int
+  userId    Int?
+  firstName String
+  lastName  String
+  email     String
+  phone     String?
+  status    String      @default("active")
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  links     DelegateParentLink[]
+
+  @@index([programYearId])
+}
+
+model DelegateParentLink {
+  id            Int         @id @default(autoincrement())
+  delegate      Delegate    @relation(fields: [delegateId], references: [id])
+  delegateId    Int
+  parent        Parent      @relation(fields: [parentId], references: [id])
+  parentId      Int
+  programYear   ProgramYear @relation(fields: [programYearId], references: [id])
+  programYearId Int
+  status        String      @default("pending")
+  createdAt     DateTime    @default(now())
+
+  @@index([delegateId])
+  @@index([parentId])
+  @@index([programYearId])
 }

--- a/src/__mocks__/prisma.ts
+++ b/src/__mocks__/prisma.ts
@@ -59,6 +59,18 @@ const prisma = {
     findUnique: jest.fn(),
     update: jest.fn(),
   },
+  parent: {
+    create: jest.fn(),
+    findMany: jest.fn(),
+    findUnique: jest.fn(),
+    update: jest.fn(),
+  },
+  delegateParentLink: {
+    create: jest.fn(),
+    findMany: jest.fn(),
+    findUnique: jest.fn(),
+    update: jest.fn(),
+  },
   log: {
     create: jest.fn().mockResolvedValue(null),
     findMany: jest.fn(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -1264,6 +1264,171 @@ app.delete('/staff/:id', async (req: express.Request, res: express.Response) => 
   res.json(updated);
 });
 
+app.post('/program-years/:id/parents', async (req: express.Request, res: express.Response) => {
+  const { id } = req.params as { id?: string };
+  const caller = (req as any).user as { userId: number };
+  const py = await prisma.programYear.findUnique({ where: { id: Number(id) } });
+  if (!py) {
+    res.status(404).json({ error: 'Not found' });
+    return;
+  }
+  const isAdmin = await isProgramAdmin(caller.userId, py.programId);
+  if (!isAdmin) {
+    res.status(403).json({ error: 'Forbidden' });
+    return;
+  }
+  const { firstName, lastName, email, phone, userId } = req.body as {
+    firstName?: string;
+    lastName?: string;
+    email?: string;
+    phone?: string;
+    userId?: number;
+  };
+  if (!firstName || !lastName || !email) {
+    res.status(400).json({ error: 'firstName, lastName, and email required' });
+    return;
+  }
+  const parent = await prisma.parent.create({
+    data: {
+      programYearId: py.id,
+      firstName,
+      lastName,
+      email,
+      phone,
+      userId,
+      status: 'active',
+    },
+  });
+  logger.info(py.programId, `Parent ${parent.id} created`);
+  res.status(201).json(parent);
+});
+
+app.get('/program-years/:id/parents', async (req: express.Request, res: express.Response) => {
+  const { id } = req.params as { id?: string };
+  const caller = (req as any).user as { userId: number };
+  const py = await prisma.programYear.findUnique({ where: { id: Number(id) } });
+  if (!py) {
+    res.status(404).json({ error: 'Not found' });
+    return;
+  }
+  const isMember = await isProgramMember(caller.userId, py.programId);
+  if (!isMember) {
+    res.status(403).json({ error: 'Forbidden' });
+    return;
+  }
+  const parents = await prisma.parent.findMany({ where: { programYearId: py.id } });
+  res.json(parents);
+});
+
+app.put('/parents/:id', async (req: express.Request, res: express.Response) => {
+  const { id } = req.params as { id?: string };
+  const caller = (req as any).user as { userId: number };
+  const parent = await prisma.parent.findUnique({ where: { id: Number(id) } });
+  if (!parent) {
+    res.status(404).json({ error: 'Not found' });
+    return;
+  }
+  const py = await prisma.programYear.findUnique({ where: { id: parent.programYearId } });
+  if (!py) {
+    res.status(404).json({ error: 'Not found' });
+    return;
+  }
+  const isAdmin = await isProgramAdmin(caller.userId, py.programId);
+  if (!isAdmin) {
+    res.status(403).json({ error: 'Forbidden' });
+    return;
+  }
+  const { firstName, lastName, email, phone, userId, status } = req.body as {
+    firstName?: string;
+    lastName?: string;
+    email?: string;
+    phone?: string;
+    userId?: number;
+    status?: string;
+  };
+  const updated = await prisma.parent.update({
+    where: { id: Number(id) },
+    data: { firstName, lastName, email, phone, userId, status },
+  });
+  logger.info(py.programId, `Parent ${parent.id} updated`);
+  res.json(updated);
+});
+
+app.delete('/parents/:id', async (req: express.Request, res: express.Response) => {
+  const { id } = req.params as { id?: string };
+  const caller = (req as any).user as { userId: number };
+  const parent = await prisma.parent.findUnique({ where: { id: Number(id) } });
+  if (!parent) {
+    res.status(404).json({ error: 'Not found' });
+    return;
+  }
+  const py = await prisma.programYear.findUnique({ where: { id: parent.programYearId } });
+  if (!py) {
+    res.status(404).json({ error: 'Not found' });
+    return;
+  }
+  const isAdmin = await isProgramAdmin(caller.userId, py.programId);
+  if (!isAdmin) {
+    res.status(403).json({ error: 'Forbidden' });
+    return;
+  }
+  const updated = await prisma.parent.update({ where: { id: Number(id) }, data: { status: 'inactive' } });
+  logger.info(py.programId, `Parent ${parent.id} removed`);
+  res.json(updated);
+});
+
+app.post('/delegate-parent-links', async (req: express.Request, res: express.Response) => {
+  const caller = (req as any).user as { userId: number };
+  const { delegateId, parentId, programYearId } = req.body as {
+    delegateId?: number;
+    parentId?: number;
+    programYearId?: number;
+  };
+  if (!delegateId || !parentId || !programYearId) {
+    res.status(400).json({ error: 'delegateId, parentId and programYearId required' });
+    return;
+  }
+  const py = await prisma.programYear.findUnique({ where: { id: programYearId } });
+  if (!py) {
+    res.status(404).json({ error: 'Not found' });
+    return;
+  }
+  const isAdmin = await isProgramAdmin(caller.userId, py.programId);
+  if (!isAdmin) {
+    res.status(403).json({ error: 'Forbidden' });
+    return;
+  }
+  const link = await prisma.delegateParentLink.create({
+    data: { delegateId, parentId, programYearId, status: 'pending' },
+  });
+  logger.info(py.programId, `Link ${link.id} created`);
+  res.status(201).json(link);
+});
+
+app.put('/delegate-parent-links/:id', async (req: express.Request, res: express.Response) => {
+  const { id } = req.params as { id?: string };
+  const caller = (req as any).user as { userId: number };
+  const link = await prisma.delegateParentLink.findUnique({ where: { id: Number(id) } });
+  if (!link) {
+    res.status(404).json({ error: 'Not found' });
+    return;
+  }
+  const py = await prisma.programYear.findUnique({ where: { id: link.programYearId } });
+  if (!py) {
+    res.status(404).json({ error: 'Not found' });
+    return;
+  }
+  const isAdmin = await isProgramAdmin(caller.userId, py.programId);
+  if (!isAdmin) {
+    res.status(403).json({ error: 'Forbidden' });
+    return;
+  }
+  const { status } = req.body as { status?: string };
+  const updated = await prisma.delegateParentLink.update({ where: { id: Number(id) }, data: { status } });
+  logger.info(py.programId, `Link ${link.id} updated`);
+  res.json(updated);
+});
+
 if (process.env.NODE_ENV !== 'test') {
   ensureDatabase();
   app.listen(port, () => {

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -1330,6 +1330,185 @@ paths:
           description: Not found
       security:
         - bearerAuth: []
+
+  /program-years/{id}/parents:
+    post:
+      tags: [parents]
+      summary: Add parent
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+          description: Program Year ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [firstName, lastName, email]
+              properties:
+                firstName:
+                  type: string
+                lastName:
+                  type: string
+                email:
+                  type: string
+                phone:
+                  type: string
+                userId:
+                  type: integer
+      responses:
+        '201':
+          description: Parent created
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+        '400':
+          description: Invalid input
+      security:
+        - bearerAuth: []
+    get:
+      tags: [parents]
+      summary: List parents for year
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+          description: Program Year ID
+      responses:
+        '200':
+          description: Array of parents
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+      security:
+        - bearerAuth: []
+  /parents/{id}:
+    put:
+      tags: [parents]
+      summary: Update parent
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                firstName:
+                  type: string
+                lastName:
+                  type: string
+                email:
+                  type: string
+                phone:
+                  type: string
+                userId:
+                  type: integer
+                status:
+                  type: string
+      responses:
+        '200':
+          description: Updated parent
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+      security:
+        - bearerAuth: []
+    delete:
+      tags: [parents]
+      summary: Remove parent
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Parent removed
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+      security:
+        - bearerAuth: []
+  /delegate-parent-links:
+    post:
+      tags: [parents]
+      summary: Create delegate-parent link
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [delegateId, parentId, programYearId]
+              properties:
+                delegateId:
+                  type: integer
+                parentId:
+                  type: integer
+                programYearId:
+                  type: integer
+      responses:
+        '201':
+          description: Link created
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+        '400':
+          description: Invalid input
+      security:
+        - bearerAuth: []
+  /delegate-parent-links/{id}:
+    put:
+      tags: [parents]
+      summary: Update delegate-parent link
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                status:
+                  type: string
+      responses:
+        '200':
+          description: Updated link
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+      security:
+        - bearerAuth: []
   /program-years/{id}:
     get:
       tags: [programs]


### PR DESCRIPTION
## Summary
- implement Parent and DelegateParentLink models
- add CRUD endpoints for parents and parent-delegate links
- update OpenAPI docs
- update spec to reflect implemented parents and links
- add tests for new endpoints

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_686aae9ce0e4832d8a214df34cfc3f2f