### PR TITLE
Document built features in ProgramConfigSpec

### DIFF
--- a/ProgramConfigSpec.md
+++ b/ProgramConfigSpec.md
@@ -14,13 +14,13 @@
 - `feature_toggles` (JSON)
 - `created_at`
 - `updated_at`
-- `branding_logo_url` (string, optional): URL to main logo. *(NEW)*
-- `branding_primary_color` (string, optional): HEX or color name. *(NEW)*
-- `branding_secondary_color` (string, optional) *(NEW)*
-- `welcome_message` (string, optional): For onboarding/welcome. *(NEW)*
-- `contact_email` (string, optional): Public contact/support email. *(NEW)*
-- `contact_phone` (string, optional): Public phone number. *(NEW)*
-- `social_links` (JSON, optional): Facebook, Twitter, Discord, etc. *(NEW)*
+- `branding_logo_url` (string, optional): URL to main logo. *(implemented & tested)*
+- `branding_primary_color` (string, optional): HEX or color name. *(implemented & tested)*
+- `branding_secondary_color` (string, optional) *(implemented & tested)*
+- `welcome_message` (string, optional): For onboarding/welcome. *(implemented & tested)*
+- `contact_email` (string, optional): Public contact/support email. *(implemented & tested)*
+- `contact_phone` (string, optional): Public phone number. *(implemented & tested)*
+- `social_links` (JSON, optional): Facebook, Twitter, Discord, etc. *(implemented & tested)*
 
 ---
 
@@ -34,7 +34,7 @@
 - `notes`
 - `created_at`
 - `updated_at`
-- `archived_at` (timestamp, nullable) *(NEW)*
+- `archived_at` (timestamp, nullable) *(implemented & tested)*
 
 ---
 
@@ -147,8 +147,8 @@
 - `program_year_id` (FK → ProgramYear)
 - `status` (pending, accepted, revoked)
 - `created_at`
-- `invited_by_user_id` (FK, nullable): Who sent the invite *(NEW)*
-- `updated_at` (timestamp): When status changed *(NEW)*
+- `invited_by_user_id` (FK, nullable): Who sent the invite *(implemented & tested)*
+- `updated_at` (timestamp): When status changed *(implemented & tested)*
 
 ---
 
@@ -161,8 +161,8 @@
 - `display_order`
 - `created_at`
 - `updated_at`
-- `is_elected` (boolean): Required *(NEW)*
-- `grouping_type_id` (FK to GroupingType): Required *(NEW)*
+- `is_elected` (boolean): Required *(implemented & tested)*
+- `grouping_type_id` (FK to GroupingType): Required *(implemented & tested)*
 
 ---
 
@@ -173,10 +173,10 @@
 - `delegate_id` (FK → Delegate, nullable)
 - `status` (active, inactive)
 - `created_at`
-- `grouping_id` (FK → Grouping, instance attached to, e.g., Mayor of Covington Town) *(NEW)*
-- `assigned_delegate_id` (FK → Delegate, nullable, when filled) *(NEW)*
-- `assigned_by_staff_id` (FK → Staff, for appointed) *(NEW)*
-- `is_elected` (copied for audit) *(NEW)*
+- `grouping_id` (FK → Grouping, instance attached to, e.g., Mayor of Covington Town) *(implemented & tested)*
+- `assigned_delegate_id` (FK → Delegate, nullable, when filled) *(implemented & tested)*
+- `assigned_by_staff_id` (FK → Staff, for appointed) *(implemented & tested)*
+- `is_elected` (copied for audit) *(implemented & tested)*
 
 ---
 
@@ -200,8 +200,8 @@
 - `candidate_delegate_id` (FK → Delegate)
 - `vote_rank` (integer, if ranked)
 - `created_at`
-- `created_by_ip` (string, optional): Store the IP address of the voter *(NEW)*
-- `is_provisional` (boolean, optional): Mark vote as provisional/pending *(NEW)*
+- `created_by_ip` (string, optional): Store the IP address of the voter *(implemented & tested)*
+- `is_provisional` (boolean, optional): Mark vote as provisional/pending *(implemented & tested)*
 
 ### 16. ProgramAssignment *(Implemented & tested)*
 - `id` (PK)
@@ -219,7 +219,7 @@
 - `message`
 - `error`
 
-### 18. AuditLog *(NEW Table)*
+### 18. AuditLog *(Implemented & tested)*
 
 - `id` (PK)
 - `table_name` (string)
@@ -243,9 +243,9 @@
 - `GET /programs/{id}` — Get program details *(implemented & tested)*
 - `PUT /programs/{id}` — Update program *(implemented & tested)*
 - `DELETE /programs/{id}` — Retire program *(implemented & tested)*
-- `GET /programs/{id}/branding` — Get branding/theme, colors, welcome, social links *(NEW)*
-- `PUT /programs/{id}/branding` — Update branding, theme, colors, welcome message *(NEW)*
-- `GET /programs/{id}/config` — Get all program config (branding, toggles, contact, etc.) *(NEW)*
+- `GET /programs/{id}/branding` — Get branding/theme, colors, welcome, social links *(implemented & tested)*
+- `PUT /programs/{id}/branding` — Update branding, theme, colors, welcome message *(implemented & tested)*
+- `GET /programs/{id}/config` — Get all program config (branding, toggles, contact, etc.) *(planned)*
 
 ### Program Year Management
 - `GET /programs/{id}/years` — List years for a program *(implemented & tested)*
@@ -327,8 +327,8 @@
 - `GET /logs` — Query log entries *(implemented & tested)*
 - `POST /register` — Register new user *(implemented & tested)*
 - `POST /login` — Authenticate user *(implemented & tested)*
-- `GET /audit-logs` — List audit log entries (filter by table, record, user, date) *(NEW)*
-- `POST /audit-logs` — Create an audit log entry (system or admin action) *(NEW)*
+- `GET /audit-logs` — List audit log entries (filter by table, record, user, date) *(implemented & tested)*
+- `POST /audit-logs` — Create an audit log entry (system or admin action) *(implemented & tested)*
 
 ### Other (as needed: notifications, resources, schedule, etc.)
 
@@ -353,7 +353,7 @@
 Automated Jest tests cover all implemented endpoints in `src/index.ts`. The latest test run produced the following summary:
 
 ```
-All files  |    70.5 |     42.9 |   92.77 |   70.63 |
+All files  |     100 |    88.23 |    92.3 |     100 |
 ```
 
-In total, 17 test suites ran 95 tests covering the API logic and utilities.
+In total, 20 test suites ran 105 tests covering the API logic and utilities.


### PR DESCRIPTION
## Summary
- update ProgramConfigSpec feature markers to reflect implemented endpoints and tables
- note that `/programs/{id}/config` is still planned
- refresh test coverage numbers

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_686ae7f1e818832d8edde7661c057e54