### PR TITLE
Refactor to modular routes

### DIFF
--- a/dist/app.js
+++ b/dist/app.js
@@ -1,0 +1,106 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.swaggerDoc = exports.loginAttempts = exports.default = void 0;
+exports.ensureDatabase = ensureDatabase;
+const express_1 = __importDefault(require("express"));
+const cors_1 = __importDefault(require("cors"));
+const child_process_1 = require("child_process");
+const jwt_1 = require("./jwt");
+const logger = __importStar(require("./logger"));
+const auth_1 = __importStar(require("./routes/auth"));
+Object.defineProperty(exports, "loginAttempts", { enumerable: true, get: function () { return auth_1.loginAttempts; } });
+const system_1 = __importStar(require("./routes/system"));
+Object.defineProperty(exports, "swaggerDoc", { enumerable: true, get: function () { return system_1.swaggerDoc; } });
+const api_1 = __importDefault(require("./routes/api"));
+const programs_1 = __importDefault(require("./routes/programs"));
+const programYears_1 = __importDefault(require("./routes/programYears"));
+const users_1 = __importDefault(require("./routes/users"));
+const app = (0, express_1.default)();
+exports.default = app;
+const corsOptions = { origin: true, credentials: true };
+app.use((0, cors_1.default)(corsOptions));
+app.use(express_1.default.json());
+app.use((req, _res, next) => {
+    const programId = req.user?.programId || 'system';
+    logger.info(programId, `${req.method} ${req.path}`);
+    next();
+});
+const jwtSecret = process.env.JWT_SECRET || 'development-secret';
+app.use((req, res, next) => {
+    if (req.path === '/login' ||
+        req.path === '/register' ||
+        req.path.startsWith('/docs')) {
+        return next();
+    }
+    const auth = req.headers.authorization;
+    if (!auth || !auth.startsWith('Bearer ')) {
+        res.status(401).json({ error: 'Unauthorized' });
+        return;
+    }
+    const token = auth.slice(7);
+    try {
+        req.user = (0, jwt_1.verify)(token, jwtSecret);
+        next();
+    }
+    catch {
+        res.status(401).json({ error: 'Unauthorized' });
+    }
+});
+function ensureDatabase() {
+    try {
+        logger.info('system', 'Running database synchronization');
+        (0, child_process_1.execSync)('npx prisma db push', { stdio: 'inherit' });
+    }
+    catch (err) {
+        logger.error('system', 'Database synchronization failed', err);
+    }
+}
+app.use(auth_1.default);
+app.use(system_1.default);
+app.use(programs_1.default);
+app.use(programYears_1.default);
+app.use(users_1.default);
+app.use(api_1.default);
+const port = process.env.PORT || 3000;
+if (process.env.NODE_ENV !== 'test') {
+    ensureDatabase();
+    app.listen(port, () => {
+        logger.info('system', `Server listening on port ${port}`);
+    });
+}

--- a/dist/index.js
+++ b/dist/index.js
@@ -33,10 +33,11 @@ var __importStar = (this && this.__importStar) || (function () {
     };
 })();
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.getUserPrograms = exports.swaggerDoc = exports.ensureDatabase = exports.loginAttempts = exports.default = void 0;
-const main_1 = __importStar(require("./main"));
-exports.default = main_1.default;
-Object.defineProperty(exports, "loginAttempts", { enumerable: true, get: function () { return main_1.loginAttempts; } });
-Object.defineProperty(exports, "ensureDatabase", { enumerable: true, get: function () { return main_1.ensureDatabase; } });
-Object.defineProperty(exports, "swaggerDoc", { enumerable: true, get: function () { return main_1.swaggerDoc; } });
-Object.defineProperty(exports, "getUserPrograms", { enumerable: true, get: function () { return main_1.getUserPrograms; } });
+exports.getUserPrograms = exports.swaggerDoc = exports.ensureDatabase = exports.loginAttempts = void 0;
+const app_1 = __importStar(require("./app"));
+Object.defineProperty(exports, "loginAttempts", { enumerable: true, get: function () { return app_1.loginAttempts; } });
+Object.defineProperty(exports, "swaggerDoc", { enumerable: true, get: function () { return app_1.swaggerDoc; } });
+Object.defineProperty(exports, "ensureDatabase", { enumerable: true, get: function () { return app_1.ensureDatabase; } });
+exports.default = app_1.default;
+var auth_1 = require("./utils/auth");
+Object.defineProperty(exports, "getUserPrograms", { enumerable: true, get: function () { return auth_1.getUserPrograms; } });

--- a/dist/routes/api.js
+++ b/dist/routes/api.js
@@ -36,618 +36,19 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.loginAttempts = exports.swaggerDoc = void 0;
-exports.getUserPrograms = getUserPrograms;
-exports.ensureDatabase = ensureDatabase;
-/* istanbul ignore file */
 const express_1 = __importDefault(require("express"));
-const cors_1 = __importDefault(require("cors"));
-const fs_1 = require("fs");
-const path_1 = __importDefault(require("path"));
-const child_process_1 = require("child_process");
-const swagger_ui_express_1 = __importDefault(require("swagger-ui-express"));
-const yaml_1 = __importDefault(require("yaml"));
-const crypto_1 = require("crypto");
-const util_1 = require("util");
-const prisma_1 = __importDefault(require("./prisma"));
-const jwt_1 = require("./jwt");
-const logger = __importStar(require("./logger"));
-const scrypt = (0, util_1.promisify)(crypto_1.scrypt);
-const app = (0, express_1.default)();
-// Configure CORS to allow credentialed requests
-const corsOptions = {
-    origin: true,
-    credentials: true,
-};
-app.use((0, cors_1.default)(corsOptions));
-app.use(express_1.default.json());
-app.use((req, _res, next) => {
-    const programId = req.user?.programId || 'system';
-    logger.info(programId, `${req.method} ${req.path}`);
-    next();
-});
-const jwtSecret = process.env.JWT_SECRET || 'development-secret';
-const loginAttempts = new Map();
-exports.loginAttempts = loginAttempts;
-const MAX_LOGIN_ATTEMPTS = 5;
-const LOGIN_WINDOW_MS = 15 * 60 * 1000; // 15 minutes
-app.use((req, res, next) => {
-    if (req.path === '/login' ||
-        req.path === '/register' ||
-        req.path.startsWith('/docs')) {
-        return next();
-    }
-    const auth = req.headers.authorization;
-    if (!auth || !auth.startsWith('Bearer ')) {
-        res.status(401).json({ error: 'Unauthorized' });
-        return;
-    }
-    const token = auth.slice(7);
-    try {
-        req.user = (0, jwt_1.verify)(token, jwtSecret);
-        next();
-    }
-    catch {
-        res.status(401).json({ error: 'Unauthorized' });
-    }
-});
-function ensureDatabase() {
-    try {
-        logger.info('system', 'Running database synchronization');
-        (0, child_process_1.execSync)('npx prisma db push', { stdio: 'inherit' });
-    }
-    catch (err) {
-        logger.error('system', 'Database synchronization failed', err);
-    }
-}
-// Load OpenAPI spec
-const openApiPath = path_1.default.join(__dirname, 'openapi.yaml');
-const openApiDoc = yaml_1.default.parse((0, fs_1.readFileSync)(openApiPath, 'utf8'));
-app.get('/docs/swagger.json', (_req, res) => {
-    res.json(openApiDoc);
-});
-// Override server URL when not in production so Swagger points to the local API
-const port = process.env.PORT || 3000;
-if (process.env.NODE_ENV !== 'production') {
-    openApiDoc.servers = [{ url: `http://localhost:${port}` }];
-}
-app.get('/docs/swagger-ui-custom.js', (_req, res) => {
-    res.sendFile(path_1.default.join(__dirname, 'swagger-ui-custom.js'));
-});
-const docsOptions = {
-    customJs: 'swagger-ui-custom.js',
-};
-app.use('/docs', swagger_ui_express_1.default.serve, swagger_ui_express_1.default.setup(openApiDoc, docsOptions));
-exports.swaggerDoc = openApiDoc;
-app.post('/register', async (req, res) => {
-    const { email, password } = req.body;
-    if (!email || !password) {
-        res.status(400).json({ error: 'Email and password required' });
-        return;
-    }
-    const existing = await prisma_1.default.user.findUnique({ where: { email } });
-    if (existing) {
-        res.status(400).json({ error: 'User already exists' });
-        return;
-    }
-    const salt = (0, crypto_1.randomBytes)(16).toString('hex');
-    const buf = (await scrypt(password, salt, 64));
-    const hashed = `${salt}:${buf.toString('hex')}`;
-    await prisma_1.default.user.create({ data: { email, password: hashed } });
-    logger.info('system', `User registered: ${email}`);
-    res.status(201).json({ message: 'User created' });
-    return;
-});
-app.post('/login', async (req, res) => {
-    const { email, password } = req.body;
-    if (!email || !password) {
-        res.status(400).json({ error: 'Email and password required' });
-        return;
-    }
-    const now = Date.now();
-    const ip = req.ip || '';
-    const attempt = loginAttempts.get(ip);
-    if (attempt && now - attempt.lastAttempt < LOGIN_WINDOW_MS && attempt.count >= MAX_LOGIN_ATTEMPTS) {
-        logger.warn('system', `Too many login attempts from ${ip}`);
-        res.status(429).json({ error: 'Too many login attempts' });
-        return;
-    }
-    const user = await prisma_1.default.user.findUnique({ where: { email } });
-    if (!user) {
-        const count = attempt && now - attempt.lastAttempt < LOGIN_WINDOW_MS ? attempt.count + 1 : 1;
-        loginAttempts.set(ip, { count, lastAttempt: now });
-        res.status(401).json({ error: 'Invalid credentials' });
-        return;
-    }
-    const [salt, storedHash] = user.password.split(':');
-    const buf = (await scrypt(password, salt, 64));
-    if (buf.toString('hex') !== storedHash) {
-        const count = attempt && now - attempt.lastAttempt < LOGIN_WINDOW_MS ? attempt.count + 1 : 1;
-        loginAttempts.set(ip, { count, lastAttempt: now });
-        res.status(401).json({ error: 'Invalid credentials' });
-        return;
-    }
-    loginAttempts.delete(ip);
-    const token = (0, jwt_1.sign)({ userId: user.id, email: user.email }, jwtSecret);
-    logger.info('system', `User logged in: ${email}`);
-    res.json({ token });
-    return;
-});
-app.get('/health', async (_req, res) => {
-    logger.info('system', 'Serving /health');
-    let dbStatus = 'ok';
-    try {
-        await prisma_1.default.$queryRaw `SELECT 1`;
-    }
-    catch (err) {
-        logger.error('system', 'Database check failed', err);
-        dbStatus = 'error';
-    }
-    res.json({ status: 'ok', database: dbStatus });
-});
-app.post('/logs', (req, res) => {
-    const { programId, level, message, error, source } = req.body;
-    if (!programId || !level || !message) {
-        res.status(400).json({ error: 'programId, level, and message required' });
-        return;
-    }
-    const lvl = level;
-    if (!['debug', 'info', 'warn', 'error'].includes(lvl)) {
-        res.status(400).json({ error: 'Invalid level' });
-        return;
-    }
-    const src = source || 'client';
-    switch (lvl) {
-        case 'debug':
-            logger.debug(programId, message, src);
-            break;
-        case 'info':
-            logger.info(programId, message, src);
-            break;
-        case 'warn':
-            logger.warn(programId, message, src);
-            break;
-        case 'error':
-            logger.error(programId, message, error, src);
-            break;
-    }
-    res.status(204).send();
-});
-app.get('/logs', async (req, res) => {
-    const { programId, level, source, dateFrom, dateTo, search, page = '1', pageSize = '50', } = req.query;
-    if (level && !['debug', 'info', 'warn', 'error'].includes(level)) {
-        res.status(400).json({ error: 'Invalid level' });
-        return;
-    }
-    let p = parseInt(page, 10);
-    if (isNaN(p) || p < 1)
-        p = 1;
-    let size = parseInt(pageSize, 10);
-    if (isNaN(size) || size < 1)
-        size = 50;
-    if (size > 100)
-        size = 100;
-    const where = {};
-    if (programId)
-        where.programId = programId;
-    if (level)
-        where.level = level;
-    if (source)
-        where.source = source;
-    if (dateFrom || dateTo) {
-        where.timestamp = {};
-        if (dateFrom)
-            where.timestamp.gte = new Date(dateFrom);
-        if (dateTo)
-            where.timestamp.lte = new Date(dateTo);
-    }
-    if (search) {
-        const contains = { contains: search, mode: 'insensitive' };
-        where.OR = [{ message: contains }, { error: contains }, { source: contains }];
-    }
-    const total = await prisma_1.default.log.count({ where });
-    const logs = await prisma_1.default.log.findMany({
-        where,
-        orderBy: { timestamp: 'desc' },
-        skip: (p - 1) * size,
-        take: size,
-    });
-    res.json({ logs, page: p, pageSize: size, total });
-});
-app.post('/audit-logs', async (req, res) => {
-    const { tableName, recordId, userId, action, changes } = req.body;
-    if (!tableName || recordId === undefined || !userId || !action) {
-        res
-            .status(400)
-            .json({ error: 'tableName, recordId, userId and action required' });
-        return;
-    }
-    const log = await prisma_1.default.auditLog.create({
-        data: {
-            tableName,
-            recordId: String(recordId),
-            userId,
-            action,
-            changes,
-        },
-    });
-    res.status(201).json(log);
-});
-app.get('/audit-logs', async (req, res) => {
-    const { tableName, recordId, userId, dateFrom, dateTo, page = '1', pageSize = '50', } = req.query;
-    let p = parseInt(page, 10);
-    if (isNaN(p) || p < 1)
-        p = 1;
-    let size = parseInt(pageSize, 10);
-    if (isNaN(size) || size < 1)
-        size = 50;
-    if (size > 100)
-        size = 100;
-    const where = {};
-    if (tableName)
-        where.tableName = tableName;
-    if (recordId)
-        where.recordId = recordId;
-    if (userId)
-        where.userId = Number(userId);
-    if (dateFrom || dateTo) {
-        where.timestamp = {};
-        if (dateFrom)
-            where.timestamp.gte = new Date(dateFrom);
-        if (dateTo)
-            where.timestamp.lte = new Date(dateTo);
-    }
-    const total = await prisma_1.default.auditLog.count({ where });
-    const logs = await prisma_1.default.auditLog.findMany({
-        where,
-        orderBy: { timestamp: 'desc' },
-        skip: (p - 1) * size,
-        take: size,
-    });
-    res.json({ auditLogs: logs, page: p, pageSize: size, total });
-});
-async function getUserPrograms(req, res) {
-    const { username } = req.params;
-    if (!username) {
-        res.status(400).json({ error: 'Username required' });
-        return;
-    }
-    const user = await prisma_1.default.user.findUnique({ where: { email: username } });
-    if (!user) {
-        res.status(404).json({ error: 'User not found' });
-        return;
-    }
-    const assignments = await prisma_1.default.programAssignment.findMany({
-        where: { userId: user.id },
-        include: { program: true },
-    });
-    const programs = assignments.map((a) => ({
-        programId: a.program.id,
-        programName: a.program.name,
-        role: a.role,
-    }));
-    programs.forEach((p) => {
-        logger.info(p.programId, `Program lookup for ${user.email}`);
-    });
-    res.json({ username: user.email, programs });
-}
-async function isProgramAdmin(userId, programId) {
-    const assignment = await prisma_1.default.programAssignment.findFirst({
-        where: { userId, programId },
-    });
-    return assignment?.role === 'admin';
-}
-async function isProgramMember(userId, programId) {
-    const assignment = await prisma_1.default.programAssignment.findFirst({
-        where: { userId, programId },
-    });
-    return Boolean(assignment);
-}
-app.post('/programs', async (req, res) => {
-    const user = req.user;
-    const { name, year, config } = req.body;
-    if (!name || !year) {
-        res.status(400).json({ error: 'name and year required' });
-        return;
-    }
-    const program = await prisma_1.default.program.create({
-        data: {
-            name,
-            year,
-            config,
-            createdBy: { connect: { id: user.userId } },
-        },
-    });
-    await prisma_1.default.programAssignment.create({
-        data: { userId: user.userId, programId: program.id, role: 'admin' },
-    });
-    logger.info(program.id, `Program created by ${user.email}`);
-    res.status(201).json({
-        id: program.id,
-        name: program.name,
-        year: program.year,
-        createdBy: user.userId,
-        roleAssigned: 'admin',
-    });
-});
-app.get('/programs', async (_req, res) => {
-    const programs = await prisma_1.default.program.findMany();
-    res.json(programs);
-});
-app.post('/programs/:programId/users', async (req, res) => {
+const prisma_1 = __importDefault(require("../prisma"));
+const logger = __importStar(require("../logger"));
+const auth_1 = require("../utils/auth");
+const router = express_1.default.Router();
+router.post('/programs/:programId/grouping-types', async (req, res) => {
     const { programId } = req.params;
     const caller = req.user;
     if (!programId) {
         res.status(400).json({ error: 'programId required' });
         return;
     }
-    const isAdmin = await isProgramAdmin(caller.userId, programId);
-    if (!isAdmin) {
-        res.status(403).json({ error: 'Forbidden' });
-        return;
-    }
-    const { userId, role } = req.body;
-    if (!userId || !role) {
-        res.status(400).json({ error: 'userId and role required' });
-        return;
-    }
-    await prisma_1.default.programAssignment.create({
-        data: { userId, programId, role },
-    });
-    logger.info(programId, `User ${userId} assigned role ${role}`);
-    res.status(201).json({
-        programId,
-        userId,
-        role,
-        status: 'assigned',
-    });
-});
-app.get('/programs/:programId/users', async (req, res) => {
-    const { programId } = req.params;
-    const caller = req.user;
-    if (!programId) {
-        res.status(400).json({ error: 'programId required' });
-        return;
-    }
-    const isAdmin = await isProgramAdmin(caller.userId, programId);
-    if (!isAdmin) {
-        res.status(403).json({ error: 'Forbidden' });
-        return;
-    }
-    const assignments = await prisma_1.default.programAssignment.findMany({
-        where: { programId },
-        select: { userId: true, role: true },
-    });
-    logger.info(programId, `Listed users for program`);
-    res.json(assignments);
-});
-app.post('/programs/:programId/years', async (req, res) => {
-    const { programId } = req.params;
-    const caller = req.user;
-    if (!programId) {
-        res.status(400).json({ error: 'programId required' });
-        return;
-    }
-    const isAdmin = await isProgramAdmin(caller.userId, programId);
-    if (!isAdmin) {
-        res.status(403).json({ error: 'Forbidden' });
-        return;
-    }
-    const { year, startDate, endDate, status, notes } = req.body;
-    if (!year) {
-        res.status(400).json({ error: 'year required' });
-        return;
-    }
-    const py = await prisma_1.default.programYear.create({
-        data: {
-            programId,
-            year,
-            startDate: startDate ? new Date(startDate) : undefined,
-            endDate: endDate ? new Date(endDate) : undefined,
-            status: status || 'active',
-            notes,
-        },
-    });
-    logger.info(programId, `Program year ${year} created`);
-    res.status(201).json(py);
-});
-app.get('/programs/:programId/years', async (req, res) => {
-    const { programId } = req.params;
-    const caller = req.user;
-    if (!programId) {
-        res.status(400).json({ error: 'programId required' });
-        return;
-    }
-    const isMember = await isProgramMember(caller.userId, programId);
-    if (!isMember) {
-        res.status(403).json({ error: 'Forbidden' });
-        return;
-    }
-    const years = await prisma_1.default.programYear.findMany({
-        where: { programId },
-        orderBy: { year: 'desc' },
-    });
-    res.json(years);
-});
-app.get('/program-years/:id', async (req, res) => {
-    const { id } = req.params;
-    const caller = req.user;
-    const py = await prisma_1.default.programYear.findUnique({ where: { id: Number(id) } });
-    if (!py) {
-        res.status(404).json({ error: 'Not found' });
-        return;
-    }
-    const isMember = await isProgramMember(caller.userId, py.programId);
-    if (!isMember) {
-        res.status(403).json({ error: 'Forbidden' });
-        return;
-    }
-    res.json(py);
-});
-app.put('/program-years/:id', async (req, res) => {
-    const { id } = req.params;
-    const caller = req.user;
-    const py = await prisma_1.default.programYear.findUnique({ where: { id: Number(id) } });
-    if (!py) {
-        res.status(404).json({ error: 'Not found' });
-        return;
-    }
-    const isAdmin = await isProgramAdmin(caller.userId, py.programId);
-    if (!isAdmin) {
-        res.status(403).json({ error: 'Forbidden' });
-        return;
-    }
-    const { startDate, endDate, status, notes } = req.body;
-    const updated = await prisma_1.default.programYear.update({
-        where: { id: Number(id) },
-        data: {
-            startDate: startDate ? new Date(startDate) : undefined,
-            endDate: endDate ? new Date(endDate) : undefined,
-            status,
-            notes,
-        },
-    });
-    logger.info(py.programId, `Program year ${py.year} updated`);
-    res.json(updated);
-});
-app.delete('/program-years/:id', async (req, res) => {
-    const { id } = req.params;
-    const caller = req.user;
-    const py = await prisma_1.default.programYear.findUnique({ where: { id: Number(id) } });
-    if (!py) {
-        res.status(404).json({ error: 'Not found' });
-        return;
-    }
-    const isAdmin = await isProgramAdmin(caller.userId, py.programId);
-    if (!isAdmin) {
-        res.status(403).json({ error: 'Forbidden' });
-        return;
-    }
-    const updated = await prisma_1.default.programYear.update({
-        where: { id: Number(id) },
-        data: { status: 'archived' },
-    });
-    logger.info(py.programId, `Program year ${py.year} archived`);
-    res.json(updated);
-});
-app.get('/user-programs/:username', getUserPrograms);
-app.get('/programs/:id', async (req, res) => {
-    const { id } = req.params;
-    const caller = req.user;
-    const program = await prisma_1.default.program.findUnique({ where: { id } });
-    if (!program) {
-        res.status(404).json({ error: 'Not found' });
-        return;
-    }
-    const member = await isProgramMember(caller.userId, id);
-    if (!member) {
-        res.status(403).json({ error: 'Forbidden' });
-        return;
-    }
-    res.json(program);
-});
-app.get('/programs/:id/branding', async (req, res) => {
-    const { id } = req.params;
-    const caller = req.user;
-    const program = await prisma_1.default.program.findUnique({ where: { id } });
-    if (!program) {
-        res.status(404).json({ error: 'Not found' });
-        return;
-    }
-    const member = await isProgramMember(caller.userId, id);
-    if (!member) {
-        res.status(403).json({ error: 'Forbidden' });
-        return;
-    }
-    const branding = {
-        brandingLogoUrl: program.brandingLogoUrl,
-        brandingPrimaryColor: program.brandingPrimaryColor,
-        brandingSecondaryColor: program.brandingSecondaryColor,
-        welcomeMessage: program.welcomeMessage,
-        contactEmail: program.contactEmail,
-        contactPhone: program.contactPhone,
-        socialLinks: program.socialLinks,
-    };
-    res.json(branding);
-});
-app.put('/programs/:id/branding', async (req, res) => {
-    const { id } = req.params;
-    const caller = req.user;
-    const program = await prisma_1.default.program.findUnique({ where: { id } });
-    if (!program) {
-        res.status(404).json({ error: 'Not found' });
-        return;
-    }
-    const isAdmin = await isProgramAdmin(caller.userId, id);
-    if (!isAdmin) {
-        res.status(403).json({ error: 'Forbidden' });
-        return;
-    }
-    const { brandingLogoUrl, brandingPrimaryColor, brandingSecondaryColor, welcomeMessage, contactEmail, contactPhone, socialLinks, } = req.body;
-    const updated = await prisma_1.default.program.update({
-        where: { id },
-        data: {
-            brandingLogoUrl,
-            brandingPrimaryColor,
-            brandingSecondaryColor,
-            welcomeMessage,
-            contactEmail,
-            contactPhone,
-            socialLinks,
-        },
-    });
-    logger.info(id, `Branding updated by ${caller.email}`);
-    res.json(updated);
-});
-app.put('/programs/:id', async (req, res) => {
-    const { id } = req.params;
-    const caller = req.user;
-    const program = await prisma_1.default.program.findUnique({ where: { id } });
-    if (!program) {
-        res.status(404).json({ error: 'Not found' });
-        return;
-    }
-    const isAdmin = await isProgramAdmin(caller.userId, id);
-    if (!isAdmin) {
-        res.status(403).json({ error: 'Forbidden' });
-        return;
-    }
-    const { name, year, config, status } = req.body;
-    const updated = await prisma_1.default.program.update({
-        where: { id },
-        data: { name, year, config, status },
-    });
-    logger.info(id, `Program updated by ${caller.email}`);
-    res.json(updated);
-});
-app.delete('/programs/:id', async (req, res) => {
-    const { id } = req.params;
-    const caller = req.user;
-    const program = await prisma_1.default.program.findUnique({ where: { id } });
-    if (!program) {
-        res.status(404).json({ error: 'Not found' });
-        return;
-    }
-    const isAdmin = await isProgramAdmin(caller.userId, id);
-    if (!isAdmin) {
-        res.status(403).json({ error: 'Forbidden' });
-        return;
-    }
-    const updated = await prisma_1.default.program.update({
-        where: { id },
-        data: { status: 'retired' },
-    });
-    logger.info(id, `Program retired by ${caller.email}`);
-    res.json(updated);
-});
-app.post('/programs/:programId/grouping-types', async (req, res) => {
-    const { programId } = req.params;
-    const caller = req.user;
-    if (!programId) {
-        res.status(400).json({ error: 'programId required' });
-        return;
-    }
-    const isAdmin = await isProgramAdmin(caller.userId, programId);
+    const isAdmin = await (0, auth_1.isProgramAdmin)(caller.userId, programId);
     if (!isAdmin) {
         res.status(403).json({ error: 'Forbidden' });
         return;
@@ -671,14 +72,14 @@ app.post('/programs/:programId/grouping-types', async (req, res) => {
     logger.info(programId, `GroupingType ${gt.id} created`);
     res.status(201).json(gt);
 });
-app.get('/programs/:programId/grouping-types', async (req, res) => {
+router.get('/programs/:programId/grouping-types', async (req, res) => {
     const { programId } = req.params;
     const caller = req.user;
     if (!programId) {
         res.status(400).json({ error: 'programId required' });
         return;
     }
-    const isMember = await isProgramMember(caller.userId, programId);
+    const isMember = await (0, auth_1.isProgramMember)(caller.userId, programId);
     if (!isMember) {
         res.status(403).json({ error: 'Forbidden' });
         return;
@@ -689,7 +90,7 @@ app.get('/programs/:programId/grouping-types', async (req, res) => {
     });
     res.json(types);
 });
-app.put('/grouping-types/:id', async (req, res) => {
+router.put('/grouping-types/:id', async (req, res) => {
     const { id } = req.params;
     const caller = req.user;
     const gt = await prisma_1.default.groupingType.findUnique({ where: { id: Number(id) } });
@@ -697,7 +98,7 @@ app.put('/grouping-types/:id', async (req, res) => {
         res.status(404).json({ error: 'Not found' });
         return;
     }
-    const isAdmin = await isProgramAdmin(caller.userId, gt.programId);
+    const isAdmin = await (0, auth_1.isProgramAdmin)(caller.userId, gt.programId);
     if (!isAdmin) {
         res.status(403).json({ error: 'Forbidden' });
         return;
@@ -716,7 +117,7 @@ app.put('/grouping-types/:id', async (req, res) => {
     logger.info(gt.programId, `GroupingType ${gt.id} updated`);
     res.json(updated);
 });
-app.delete('/grouping-types/:id', async (req, res) => {
+router.delete('/grouping-types/:id', async (req, res) => {
     const { id } = req.params;
     const caller = req.user;
     const gt = await prisma_1.default.groupingType.findUnique({ where: { id: Number(id) } });
@@ -724,7 +125,7 @@ app.delete('/grouping-types/:id', async (req, res) => {
         res.status(404).json({ error: 'Not found' });
         return;
     }
-    const isAdmin = await isProgramAdmin(caller.userId, gt.programId);
+    const isAdmin = await (0, auth_1.isProgramAdmin)(caller.userId, gt.programId);
     if (!isAdmin) {
         res.status(403).json({ error: 'Forbidden' });
         return;
@@ -736,14 +137,14 @@ app.delete('/grouping-types/:id', async (req, res) => {
     logger.info(gt.programId, `GroupingType ${gt.id} retired`);
     res.json(updated);
 });
-app.post('/programs/:programId/groupings', async (req, res) => {
+router.post('/programs/:programId/groupings', async (req, res) => {
     const { programId } = req.params;
     const caller = req.user;
     if (!programId) {
         res.status(400).json({ error: 'programId required' });
         return;
     }
-    const isAdmin = await isProgramAdmin(caller.userId, programId);
+    const isAdmin = await (0, auth_1.isProgramAdmin)(caller.userId, programId);
     if (!isAdmin) {
         res.status(403).json({ error: 'Forbidden' });
         return;
@@ -767,14 +168,14 @@ app.post('/programs/:programId/groupings', async (req, res) => {
     logger.info(programId, `Grouping ${grouping.id} created`);
     res.status(201).json(grouping);
 });
-app.get('/programs/:programId/groupings', async (req, res) => {
+router.get('/programs/:programId/groupings', async (req, res) => {
     const { programId } = req.params;
     const caller = req.user;
     if (!programId) {
         res.status(400).json({ error: 'programId required' });
         return;
     }
-    const isMember = await isProgramMember(caller.userId, programId);
+    const isMember = await (0, auth_1.isProgramMember)(caller.userId, programId);
     if (!isMember) {
         res.status(403).json({ error: 'Forbidden' });
         return;
@@ -785,7 +186,7 @@ app.get('/programs/:programId/groupings', async (req, res) => {
     });
     res.json(groupings);
 });
-app.put('/groupings/:id', async (req, res) => {
+router.put('/groupings/:id', async (req, res) => {
     const { id } = req.params;
     const caller = req.user;
     const grouping = await prisma_1.default.grouping.findUnique({ where: { id: Number(id) } });
@@ -793,7 +194,7 @@ app.put('/groupings/:id', async (req, res) => {
         res.status(404).json({ error: 'Not found' });
         return;
     }
-    const isAdmin = await isProgramAdmin(caller.userId, grouping.programId);
+    const isAdmin = await (0, auth_1.isProgramAdmin)(caller.userId, grouping.programId);
     if (!isAdmin) {
         res.status(403).json({ error: 'Forbidden' });
         return;
@@ -806,7 +207,7 @@ app.put('/groupings/:id', async (req, res) => {
     logger.info(grouping.programId, `Grouping ${grouping.id} updated`);
     res.json(updated);
 });
-app.delete('/groupings/:id', async (req, res) => {
+router.delete('/groupings/:id', async (req, res) => {
     const { id } = req.params;
     const caller = req.user;
     const grouping = await prisma_1.default.grouping.findUnique({ where: { id: Number(id) } });
@@ -814,7 +215,7 @@ app.delete('/groupings/:id', async (req, res) => {
         res.status(404).json({ error: 'Not found' });
         return;
     }
-    const isAdmin = await isProgramAdmin(caller.userId, grouping.programId);
+    const isAdmin = await (0, auth_1.isProgramAdmin)(caller.userId, grouping.programId);
     if (!isAdmin) {
         res.status(403).json({ error: 'Forbidden' });
         return;
@@ -826,7 +227,7 @@ app.delete('/groupings/:id', async (req, res) => {
     logger.info(grouping.programId, `Grouping ${grouping.id} retired`);
     res.json(updated);
 });
-app.post('/program-years/:id/groupings/activate', async (req, res) => {
+router.post('/program-years/:id/groupings/activate', async (req, res) => {
     const { id } = req.params;
     const caller = req.user;
     const py = await prisma_1.default.programYear.findUnique({ where: { id: Number(id) } });
@@ -834,7 +235,7 @@ app.post('/program-years/:id/groupings/activate', async (req, res) => {
         res.status(404).json({ error: 'Not found' });
         return;
     }
-    const isAdmin = await isProgramAdmin(caller.userId, py.programId);
+    const isAdmin = await (0, auth_1.isProgramAdmin)(caller.userId, py.programId);
     if (!isAdmin) {
         res.status(403).json({ error: 'Forbidden' });
         return;
@@ -850,7 +251,7 @@ app.post('/program-years/:id/groupings/activate', async (req, res) => {
     logger.info(py.programId, `Activated ${records.length} groupings for PY ${py.year}`);
     res.status(201).json(records);
 });
-app.get('/program-years/:id/groupings', async (req, res) => {
+router.get('/program-years/:id/groupings', async (req, res) => {
     const { id } = req.params;
     const caller = req.user;
     const py = await prisma_1.default.programYear.findUnique({ where: { id: Number(id) } });
@@ -858,7 +259,7 @@ app.get('/program-years/:id/groupings', async (req, res) => {
         res.status(404).json({ error: 'Not found' });
         return;
     }
-    const isMember = await isProgramMember(caller.userId, py.programId);
+    const isMember = await (0, auth_1.isProgramMember)(caller.userId, py.programId);
     if (!isMember) {
         res.status(403).json({ error: 'Forbidden' });
         return;
@@ -869,14 +270,14 @@ app.get('/program-years/:id/groupings', async (req, res) => {
     });
     res.json(records);
 });
-app.post('/programs/:programId/parties', async (req, res) => {
+router.post('/programs/:programId/parties', async (req, res) => {
     const { programId } = req.params;
     const caller = req.user;
     if (!programId) {
         res.status(400).json({ error: 'programId required' });
         return;
     }
-    const isAdmin = await isProgramAdmin(caller.userId, programId);
+    const isAdmin = await (0, auth_1.isProgramAdmin)(caller.userId, programId);
     if (!isAdmin) {
         res.status(403).json({ error: 'Forbidden' });
         return;
@@ -892,14 +293,14 @@ app.post('/programs/:programId/parties', async (req, res) => {
     logger.info(programId, `Party ${party.id} created`);
     res.status(201).json(party);
 });
-app.get('/programs/:programId/parties', async (req, res) => {
+router.get('/programs/:programId/parties', async (req, res) => {
     const { programId } = req.params;
     const caller = req.user;
     if (!programId) {
         res.status(400).json({ error: 'programId required' });
         return;
     }
-    const isMember = await isProgramMember(caller.userId, programId);
+    const isMember = await (0, auth_1.isProgramMember)(caller.userId, programId);
     if (!isMember) {
         res.status(403).json({ error: 'Forbidden' });
         return;
@@ -910,7 +311,7 @@ app.get('/programs/:programId/parties', async (req, res) => {
     });
     res.json(parties);
 });
-app.put('/parties/:id', async (req, res) => {
+router.put('/parties/:id', async (req, res) => {
     const { id } = req.params;
     const caller = req.user;
     const party = await prisma_1.default.party.findUnique({ where: { id: Number(id) } });
@@ -918,7 +319,7 @@ app.put('/parties/:id', async (req, res) => {
         res.status(404).json({ error: 'Not found' });
         return;
     }
-    const isAdmin = await isProgramAdmin(caller.userId, party.programId);
+    const isAdmin = await (0, auth_1.isProgramAdmin)(caller.userId, party.programId);
     if (!isAdmin) {
         res.status(403).json({ error: 'Forbidden' });
         return;
@@ -931,7 +332,7 @@ app.put('/parties/:id', async (req, res) => {
     logger.info(party.programId, `Party ${party.id} updated`);
     res.json(updated);
 });
-app.delete('/parties/:id', async (req, res) => {
+router.delete('/parties/:id', async (req, res) => {
     const { id } = req.params;
     const caller = req.user;
     const party = await prisma_1.default.party.findUnique({ where: { id: Number(id) } });
@@ -939,7 +340,7 @@ app.delete('/parties/:id', async (req, res) => {
         res.status(404).json({ error: 'Not found' });
         return;
     }
-    const isAdmin = await isProgramAdmin(caller.userId, party.programId);
+    const isAdmin = await (0, auth_1.isProgramAdmin)(caller.userId, party.programId);
     if (!isAdmin) {
         res.status(403).json({ error: 'Forbidden' });
         return;
@@ -951,7 +352,7 @@ app.delete('/parties/:id', async (req, res) => {
     logger.info(party.programId, `Party ${party.id} retired`);
     res.json(updated);
 });
-app.post('/program-years/:id/parties/activate', async (req, res) => {
+router.post('/program-years/:id/parties/activate', async (req, res) => {
     const { id } = req.params;
     const caller = req.user;
     const py = await prisma_1.default.programYear.findUnique({ where: { id: Number(id) } });
@@ -959,7 +360,7 @@ app.post('/program-years/:id/parties/activate', async (req, res) => {
         res.status(404).json({ error: 'Not found' });
         return;
     }
-    const isAdmin = await isProgramAdmin(caller.userId, py.programId);
+    const isAdmin = await (0, auth_1.isProgramAdmin)(caller.userId, py.programId);
     if (!isAdmin) {
         res.status(403).json({ error: 'Forbidden' });
         return;
@@ -975,7 +376,7 @@ app.post('/program-years/:id/parties/activate', async (req, res) => {
     logger.info(py.programId, `Activated ${records.length} parties for PY ${py.year}`);
     res.status(201).json(records);
 });
-app.get('/program-years/:id/parties', async (req, res) => {
+router.get('/program-years/:id/parties', async (req, res) => {
     const { id } = req.params;
     const caller = req.user;
     const py = await prisma_1.default.programYear.findUnique({ where: { id: Number(id) } });
@@ -983,7 +384,7 @@ app.get('/program-years/:id/parties', async (req, res) => {
         res.status(404).json({ error: 'Not found' });
         return;
     }
-    const isMember = await isProgramMember(caller.userId, py.programId);
+    const isMember = await (0, auth_1.isProgramMember)(caller.userId, py.programId);
     if (!isMember) {
         res.status(403).json({ error: 'Forbidden' });
         return;
@@ -994,14 +395,14 @@ app.get('/program-years/:id/parties', async (req, res) => {
     });
     res.json(records);
 });
-app.post('/programs/:programId/positions', async (req, res) => {
+router.post('/programs/:programId/positions', async (req, res) => {
     const { programId } = req.params;
     const caller = req.user;
     if (!programId) {
         res.status(400).json({ error: 'programId required' });
         return;
     }
-    const isAdmin = await isProgramAdmin(caller.userId, programId);
+    const isAdmin = await (0, auth_1.isProgramAdmin)(caller.userId, programId);
     if (!isAdmin) {
         res.status(403).json({ error: 'Forbidden' });
         return;
@@ -1017,14 +418,14 @@ app.post('/programs/:programId/positions', async (req, res) => {
     logger.info(programId, `Position ${position.id} created`);
     res.status(201).json(position);
 });
-app.get('/programs/:programId/positions', async (req, res) => {
+router.get('/programs/:programId/positions', async (req, res) => {
     const { programId } = req.params;
     const caller = req.user;
     if (!programId) {
         res.status(400).json({ error: 'programId required' });
         return;
     }
-    const isMember = await isProgramMember(caller.userId, programId);
+    const isMember = await (0, auth_1.isProgramMember)(caller.userId, programId);
     if (!isMember) {
         res.status(403).json({ error: 'Forbidden' });
         return;
@@ -1035,7 +436,7 @@ app.get('/programs/:programId/positions', async (req, res) => {
     });
     res.json(positions);
 });
-app.put('/positions/:id', async (req, res) => {
+router.put('/positions/:id', async (req, res) => {
     const { id } = req.params;
     const caller = req.user;
     const position = await prisma_1.default.position.findUnique({ where: { id: Number(id) } });
@@ -1043,7 +444,7 @@ app.put('/positions/:id', async (req, res) => {
         res.status(404).json({ error: 'Not found' });
         return;
     }
-    const isAdmin = await isProgramAdmin(caller.userId, position.programId);
+    const isAdmin = await (0, auth_1.isProgramAdmin)(caller.userId, position.programId);
     if (!isAdmin) {
         res.status(403).json({ error: 'Forbidden' });
         return;
@@ -1056,7 +457,7 @@ app.put('/positions/:id', async (req, res) => {
     logger.info(position.programId, `Position ${position.id} updated`);
     res.json(updated);
 });
-app.delete('/positions/:id', async (req, res) => {
+router.delete('/positions/:id', async (req, res) => {
     const { id } = req.params;
     const caller = req.user;
     const position = await prisma_1.default.position.findUnique({ where: { id: Number(id) } });
@@ -1064,7 +465,7 @@ app.delete('/positions/:id', async (req, res) => {
         res.status(404).json({ error: 'Not found' });
         return;
     }
-    const isAdmin = await isProgramAdmin(caller.userId, position.programId);
+    const isAdmin = await (0, auth_1.isProgramAdmin)(caller.userId, position.programId);
     if (!isAdmin) {
         res.status(403).json({ error: 'Forbidden' });
         return;
@@ -1073,7 +474,7 @@ app.delete('/positions/:id', async (req, res) => {
     logger.info(position.programId, `Position ${position.id} retired`);
     res.json(updated);
 });
-app.post('/program-years/:id/positions', async (req, res) => {
+router.post('/program-years/:id/positions', async (req, res) => {
     const { id } = req.params;
     const caller = req.user;
     const py = await prisma_1.default.programYear.findUnique({ where: { id: Number(id) } });
@@ -1081,7 +482,7 @@ app.post('/program-years/:id/positions', async (req, res) => {
         res.status(404).json({ error: 'Not found' });
         return;
     }
-    const isAdmin = await isProgramAdmin(caller.userId, py.programId);
+    const isAdmin = await (0, auth_1.isProgramAdmin)(caller.userId, py.programId);
     if (!isAdmin) {
         res.status(403).json({ error: 'Forbidden' });
         return;
@@ -1097,7 +498,7 @@ app.post('/program-years/:id/positions', async (req, res) => {
     logger.info(py.programId, `ProgramYearPosition ${pypos.id} created`);
     res.status(201).json(pypos);
 });
-app.get('/program-years/:id/positions', async (req, res) => {
+router.get('/program-years/:id/positions', async (req, res) => {
     const { id } = req.params;
     const caller = req.user;
     const py = await prisma_1.default.programYear.findUnique({ where: { id: Number(id) } });
@@ -1105,7 +506,7 @@ app.get('/program-years/:id/positions', async (req, res) => {
         res.status(404).json({ error: 'Not found' });
         return;
     }
-    const isMember = await isProgramMember(caller.userId, py.programId);
+    const isMember = await (0, auth_1.isProgramMember)(caller.userId, py.programId);
     if (!isMember) {
         res.status(403).json({ error: 'Forbidden' });
         return;
@@ -1116,7 +517,7 @@ app.get('/program-years/:id/positions', async (req, res) => {
     });
     res.json(records);
 });
-app.put('/program-year-positions/:id', async (req, res) => {
+router.put('/program-year-positions/:id', async (req, res) => {
     const { id } = req.params;
     const caller = req.user;
     const record = await prisma_1.default.programYearPosition.findUnique({ where: { id: Number(id) } });
@@ -1129,7 +530,7 @@ app.put('/program-year-positions/:id', async (req, res) => {
         res.status(404).json({ error: 'Not found' });
         return;
     }
-    const isAdmin = await isProgramAdmin(caller.userId, py.programId);
+    const isAdmin = await (0, auth_1.isProgramAdmin)(caller.userId, py.programId);
     if (!isAdmin) {
         res.status(403).json({ error: 'Forbidden' });
         return;
@@ -1139,7 +540,7 @@ app.put('/program-year-positions/:id', async (req, res) => {
     logger.info(py.programId, `ProgramYearPosition ${record.id} updated`);
     res.json(updated);
 });
-app.delete('/program-year-positions/:id', async (req, res) => {
+router.delete('/program-year-positions/:id', async (req, res) => {
     const { id } = req.params;
     const caller = req.user;
     const record = await prisma_1.default.programYearPosition.findUnique({ where: { id: Number(id) } });
@@ -1152,7 +553,7 @@ app.delete('/program-year-positions/:id', async (req, res) => {
         res.status(404).json({ error: 'Not found' });
         return;
     }
-    const isAdmin = await isProgramAdmin(caller.userId, py.programId);
+    const isAdmin = await (0, auth_1.isProgramAdmin)(caller.userId, py.programId);
     if (!isAdmin) {
         res.status(403).json({ error: 'Forbidden' });
         return;
@@ -1161,7 +562,7 @@ app.delete('/program-year-positions/:id', async (req, res) => {
     logger.info(py.programId, `ProgramYearPosition ${record.id} removed`);
     res.json(updated);
 });
-app.post('/program-years/:id/delegates', async (req, res) => {
+router.post('/program-years/:id/delegates', async (req, res) => {
     const { id } = req.params;
     const caller = req.user;
     const py = await prisma_1.default.programYear.findUnique({ where: { id: Number(id) } });
@@ -1169,7 +570,7 @@ app.post('/program-years/:id/delegates', async (req, res) => {
         res.status(404).json({ error: 'Not found' });
         return;
     }
-    const isAdmin = await isProgramAdmin(caller.userId, py.programId);
+    const isAdmin = await (0, auth_1.isProgramAdmin)(caller.userId, py.programId);
     if (!isAdmin) {
         res.status(403).json({ error: 'Forbidden' });
         return;
@@ -1195,7 +596,7 @@ app.post('/program-years/:id/delegates', async (req, res) => {
     logger.info(py.programId, `Delegate ${delegate.id} created`);
     res.status(201).json(delegate);
 });
-app.get('/program-years/:id/delegates', async (req, res) => {
+router.get('/program-years/:id/delegates', async (req, res) => {
     const { id } = req.params;
     const caller = req.user;
     const py = await prisma_1.default.programYear.findUnique({ where: { id: Number(id) } });
@@ -1203,7 +604,7 @@ app.get('/program-years/:id/delegates', async (req, res) => {
         res.status(404).json({ error: 'Not found' });
         return;
     }
-    const isMember = await isProgramMember(caller.userId, py.programId);
+    const isMember = await (0, auth_1.isProgramMember)(caller.userId, py.programId);
     if (!isMember) {
         res.status(403).json({ error: 'Forbidden' });
         return;
@@ -1211,7 +612,7 @@ app.get('/program-years/:id/delegates', async (req, res) => {
     const delegates = await prisma_1.default.delegate.findMany({ where: { programYearId: py.id } });
     res.json(delegates);
 });
-app.put('/delegates/:id', async (req, res) => {
+router.put('/delegates/:id', async (req, res) => {
     const { id } = req.params;
     const caller = req.user;
     const delegate = await prisma_1.default.delegate.findUnique({ where: { id: Number(id) } });
@@ -1224,7 +625,7 @@ app.put('/delegates/:id', async (req, res) => {
         res.status(404).json({ error: 'Not found' });
         return;
     }
-    const isAdmin = await isProgramAdmin(caller.userId, py.programId);
+    const isAdmin = await (0, auth_1.isProgramAdmin)(caller.userId, py.programId);
     if (!isAdmin) {
         res.status(403).json({ error: 'Forbidden' });
         return;
@@ -1237,7 +638,7 @@ app.put('/delegates/:id', async (req, res) => {
     logger.info(py.programId, `Delegate ${delegate.id} updated`);
     res.json(updated);
 });
-app.delete('/delegates/:id', async (req, res) => {
+router.delete('/delegates/:id', async (req, res) => {
     const { id } = req.params;
     const caller = req.user;
     const delegate = await prisma_1.default.delegate.findUnique({ where: { id: Number(id) } });
@@ -1250,7 +651,7 @@ app.delete('/delegates/:id', async (req, res) => {
         res.status(404).json({ error: 'Not found' });
         return;
     }
-    const isAdmin = await isProgramAdmin(caller.userId, py.programId);
+    const isAdmin = await (0, auth_1.isProgramAdmin)(caller.userId, py.programId);
     if (!isAdmin) {
         res.status(403).json({ error: 'Forbidden' });
         return;
@@ -1262,7 +663,7 @@ app.delete('/delegates/:id', async (req, res) => {
     logger.info(py.programId, `Delegate ${delegate.id} withdrawn`);
     res.json(updated);
 });
-app.post('/program-years/:id/staff', async (req, res) => {
+router.post('/program-years/:id/staff', async (req, res) => {
     const { id } = req.params;
     const caller = req.user;
     const py = await prisma_1.default.programYear.findUnique({ where: { id: Number(id) } });
@@ -1270,7 +671,7 @@ app.post('/program-years/:id/staff', async (req, res) => {
         res.status(404).json({ error: 'Not found' });
         return;
     }
-    const isAdmin = await isProgramAdmin(caller.userId, py.programId);
+    const isAdmin = await (0, auth_1.isProgramAdmin)(caller.userId, py.programId);
     if (!isAdmin) {
         res.status(403).json({ error: 'Forbidden' });
         return;
@@ -1296,7 +697,7 @@ app.post('/program-years/:id/staff', async (req, res) => {
     logger.info(py.programId, `Staff ${staff.id} created`);
     res.status(201).json(staff);
 });
-app.get('/program-years/:id/staff', async (req, res) => {
+router.get('/program-years/:id/staff', async (req, res) => {
     const { id } = req.params;
     const caller = req.user;
     const py = await prisma_1.default.programYear.findUnique({ where: { id: Number(id) } });
@@ -1304,7 +705,7 @@ app.get('/program-years/:id/staff', async (req, res) => {
         res.status(404).json({ error: 'Not found' });
         return;
     }
-    const isMember = await isProgramMember(caller.userId, py.programId);
+    const isMember = await (0, auth_1.isProgramMember)(caller.userId, py.programId);
     if (!isMember) {
         res.status(403).json({ error: 'Forbidden' });
         return;
@@ -1312,7 +713,7 @@ app.get('/program-years/:id/staff', async (req, res) => {
     const staffList = await prisma_1.default.staff.findMany({ where: { programYearId: py.id } });
     res.json(staffList);
 });
-app.put('/staff/:id', async (req, res) => {
+router.put('/staff/:id', async (req, res) => {
     const { id } = req.params;
     const caller = req.user;
     const staff = await prisma_1.default.staff.findUnique({ where: { id: Number(id) } });
@@ -1325,7 +726,7 @@ app.put('/staff/:id', async (req, res) => {
         res.status(404).json({ error: 'Not found' });
         return;
     }
-    const isAdmin = await isProgramAdmin(caller.userId, py.programId);
+    const isAdmin = await (0, auth_1.isProgramAdmin)(caller.userId, py.programId);
     if (!isAdmin) {
         res.status(403).json({ error: 'Forbidden' });
         return;
@@ -1338,7 +739,7 @@ app.put('/staff/:id', async (req, res) => {
     logger.info(py.programId, `Staff ${staff.id} updated`);
     res.json(updated);
 });
-app.delete('/staff/:id', async (req, res) => {
+router.delete('/staff/:id', async (req, res) => {
     const { id } = req.params;
     const caller = req.user;
     const staff = await prisma_1.default.staff.findUnique({ where: { id: Number(id) } });
@@ -1351,7 +752,7 @@ app.delete('/staff/:id', async (req, res) => {
         res.status(404).json({ error: 'Not found' });
         return;
     }
-    const isAdmin = await isProgramAdmin(caller.userId, py.programId);
+    const isAdmin = await (0, auth_1.isProgramAdmin)(caller.userId, py.programId);
     if (!isAdmin) {
         res.status(403).json({ error: 'Forbidden' });
         return;
@@ -1360,7 +761,7 @@ app.delete('/staff/:id', async (req, res) => {
     logger.info(py.programId, `Staff ${staff.id} removed`);
     res.json(updated);
 });
-app.post('/program-years/:id/parents', async (req, res) => {
+router.post('/program-years/:id/parents', async (req, res) => {
     const { id } = req.params;
     const caller = req.user;
     const py = await prisma_1.default.programYear.findUnique({ where: { id: Number(id) } });
@@ -1368,7 +769,7 @@ app.post('/program-years/:id/parents', async (req, res) => {
         res.status(404).json({ error: 'Not found' });
         return;
     }
-    const isAdmin = await isProgramAdmin(caller.userId, py.programId);
+    const isAdmin = await (0, auth_1.isProgramAdmin)(caller.userId, py.programId);
     if (!isAdmin) {
         res.status(403).json({ error: 'Forbidden' });
         return;
@@ -1392,7 +793,7 @@ app.post('/program-years/:id/parents', async (req, res) => {
     logger.info(py.programId, `Parent ${parent.id} created`);
     res.status(201).json(parent);
 });
-app.get('/program-years/:id/parents', async (req, res) => {
+router.get('/program-years/:id/parents', async (req, res) => {
     const { id } = req.params;
     const caller = req.user;
     const py = await prisma_1.default.programYear.findUnique({ where: { id: Number(id) } });
@@ -1400,7 +801,7 @@ app.get('/program-years/:id/parents', async (req, res) => {
         res.status(404).json({ error: 'Not found' });
         return;
     }
-    const isMember = await isProgramMember(caller.userId, py.programId);
+    const isMember = await (0, auth_1.isProgramMember)(caller.userId, py.programId);
     if (!isMember) {
         res.status(403).json({ error: 'Forbidden' });
         return;
@@ -1408,7 +809,7 @@ app.get('/program-years/:id/parents', async (req, res) => {
     const parents = await prisma_1.default.parent.findMany({ where: { programYearId: py.id } });
     res.json(parents);
 });
-app.put('/parents/:id', async (req, res) => {
+router.put('/parents/:id', async (req, res) => {
     const { id } = req.params;
     const caller = req.user;
     const parent = await prisma_1.default.parent.findUnique({ where: { id: Number(id) } });
@@ -1421,7 +822,7 @@ app.put('/parents/:id', async (req, res) => {
         res.status(404).json({ error: 'Not found' });
         return;
     }
-    const isAdmin = await isProgramAdmin(caller.userId, py.programId);
+    const isAdmin = await (0, auth_1.isProgramAdmin)(caller.userId, py.programId);
     if (!isAdmin) {
         res.status(403).json({ error: 'Forbidden' });
         return;
@@ -1434,7 +835,7 @@ app.put('/parents/:id', async (req, res) => {
     logger.info(py.programId, `Parent ${parent.id} updated`);
     res.json(updated);
 });
-app.delete('/parents/:id', async (req, res) => {
+router.delete('/parents/:id', async (req, res) => {
     const { id } = req.params;
     const caller = req.user;
     const parent = await prisma_1.default.parent.findUnique({ where: { id: Number(id) } });
@@ -1447,7 +848,7 @@ app.delete('/parents/:id', async (req, res) => {
         res.status(404).json({ error: 'Not found' });
         return;
     }
-    const isAdmin = await isProgramAdmin(caller.userId, py.programId);
+    const isAdmin = await (0, auth_1.isProgramAdmin)(caller.userId, py.programId);
     if (!isAdmin) {
         res.status(403).json({ error: 'Forbidden' });
         return;
@@ -1456,7 +857,7 @@ app.delete('/parents/:id', async (req, res) => {
     logger.info(py.programId, `Parent ${parent.id} removed`);
     res.json(updated);
 });
-app.post('/delegate-parent-links', async (req, res) => {
+router.post('/delegate-parent-links', async (req, res) => {
     const caller = req.user;
     const { delegateId, parentId, programYearId } = req.body;
     if (!delegateId || !parentId || !programYearId) {
@@ -1468,7 +869,7 @@ app.post('/delegate-parent-links', async (req, res) => {
         res.status(404).json({ error: 'Not found' });
         return;
     }
-    const isAdmin = await isProgramAdmin(caller.userId, py.programId);
+    const isAdmin = await (0, auth_1.isProgramAdmin)(caller.userId, py.programId);
     if (!isAdmin) {
         res.status(403).json({ error: 'Forbidden' });
         return;
@@ -1479,7 +880,7 @@ app.post('/delegate-parent-links', async (req, res) => {
     logger.info(py.programId, `Link ${link.id} created`);
     res.status(201).json(link);
 });
-app.put('/delegate-parent-links/:id', async (req, res) => {
+router.put('/delegate-parent-links/:id', async (req, res) => {
     const { id } = req.params;
     const caller = req.user;
     const link = await prisma_1.default.delegateParentLink.findUnique({ where: { id: Number(id) } });
@@ -1492,7 +893,7 @@ app.put('/delegate-parent-links/:id', async (req, res) => {
         res.status(404).json({ error: 'Not found' });
         return;
     }
-    const isAdmin = await isProgramAdmin(caller.userId, py.programId);
+    const isAdmin = await (0, auth_1.isProgramAdmin)(caller.userId, py.programId);
     if (!isAdmin) {
         res.status(403).json({ error: 'Forbidden' });
         return;
@@ -1502,7 +903,7 @@ app.put('/delegate-parent-links/:id', async (req, res) => {
     logger.info(py.programId, `Link ${link.id} updated`);
     res.json(updated);
 });
-app.post('/program-years/:id/elections', async (req, res) => {
+router.post('/program-years/:id/elections', async (req, res) => {
     const { id } = req.params;
     const caller = req.user;
     const py = await prisma_1.default.programYear.findUnique({ where: { id: Number(id) } });
@@ -1510,7 +911,7 @@ app.post('/program-years/:id/elections', async (req, res) => {
         res.status(404).json({ error: 'Not found' });
         return;
     }
-    const isAdmin = await isProgramAdmin(caller.userId, py.programId);
+    const isAdmin = await (0, auth_1.isProgramAdmin)(caller.userId, py.programId);
     if (!isAdmin) {
         res.status(403).json({ error: 'Forbidden' });
         return;
@@ -1534,7 +935,7 @@ app.post('/program-years/:id/elections', async (req, res) => {
     logger.info(py.programId, `Election ${election.id} created`);
     res.status(201).json(election);
 });
-app.get('/program-years/:id/elections', async (req, res) => {
+router.get('/program-years/:id/elections', async (req, res) => {
     const { id } = req.params;
     const caller = req.user;
     const py = await prisma_1.default.programYear.findUnique({ where: { id: Number(id) } });
@@ -1542,7 +943,7 @@ app.get('/program-years/:id/elections', async (req, res) => {
         res.status(404).json({ error: 'Not found' });
         return;
     }
-    const isMember = await isProgramMember(caller.userId, py.programId);
+    const isMember = await (0, auth_1.isProgramMember)(caller.userId, py.programId);
     if (!isMember) {
         res.status(403).json({ error: 'Forbidden' });
         return;
@@ -1550,7 +951,7 @@ app.get('/program-years/:id/elections', async (req, res) => {
     const elections = await prisma_1.default.election.findMany({ where: { programYearId: py.id } });
     res.json(elections);
 });
-app.put('/elections/:id', async (req, res) => {
+router.put('/elections/:id', async (req, res) => {
     const { id } = req.params;
     const caller = req.user;
     const election = await prisma_1.default.election.findUnique({ where: { id: Number(id) } });
@@ -1563,7 +964,7 @@ app.put('/elections/:id', async (req, res) => {
         res.status(404).json({ error: 'Not found' });
         return;
     }
-    const isAdmin = await isProgramAdmin(caller.userId, py.programId);
+    const isAdmin = await (0, auth_1.isProgramAdmin)(caller.userId, py.programId);
     if (!isAdmin) {
         res.status(403).json({ error: 'Forbidden' });
         return;
@@ -1580,7 +981,7 @@ app.put('/elections/:id', async (req, res) => {
     logger.info(py.programId, `Election ${election.id} updated`);
     res.json(updated);
 });
-app.delete('/elections/:id', async (req, res) => {
+router.delete('/elections/:id', async (req, res) => {
     const { id } = req.params;
     const caller = req.user;
     const election = await prisma_1.default.election.findUnique({ where: { id: Number(id) } });
@@ -1593,7 +994,7 @@ app.delete('/elections/:id', async (req, res) => {
         res.status(404).json({ error: 'Not found' });
         return;
     }
-    const isAdmin = await isProgramAdmin(caller.userId, py.programId);
+    const isAdmin = await (0, auth_1.isProgramAdmin)(caller.userId, py.programId);
     if (!isAdmin) {
         res.status(403).json({ error: 'Forbidden' });
         return;
@@ -1602,7 +1003,7 @@ app.delete('/elections/:id', async (req, res) => {
     logger.info(py.programId, `Election ${election.id} removed`);
     res.json(updated);
 });
-app.post('/elections/:id/vote', async (req, res) => {
+router.post('/elections/:id/vote', async (req, res) => {
     const { id } = req.params;
     const caller = req.user;
     const election = await prisma_1.default.election.findUnique({ where: { id: Number(id) } });
@@ -1615,7 +1016,7 @@ app.post('/elections/:id/vote', async (req, res) => {
         res.status(404).json({ error: 'Not found' });
         return;
     }
-    const isMember = await isProgramMember(caller.userId, py.programId);
+    const isMember = await (0, auth_1.isProgramMember)(caller.userId, py.programId);
     if (!isMember) {
         res.status(403).json({ error: 'Forbidden' });
         return;
@@ -1631,7 +1032,7 @@ app.post('/elections/:id/vote', async (req, res) => {
     logger.info(py.programId, `Vote ${vote.id} recorded`);
     res.status(201).json(vote);
 });
-app.get('/elections/:id/results', async (req, res) => {
+router.get('/elections/:id/results', async (req, res) => {
     const { id } = req.params;
     const caller = req.user;
     const election = await prisma_1.default.election.findUnique({ where: { id: Number(id) } });
@@ -1644,7 +1045,7 @@ app.get('/elections/:id/results', async (req, res) => {
         res.status(404).json({ error: 'Not found' });
         return;
     }
-    const isMember = await isProgramMember(caller.userId, py.programId);
+    const isMember = await (0, auth_1.isProgramMember)(caller.userId, py.programId);
     if (!isMember) {
         res.status(403).json({ error: 'Forbidden' });
         return;
@@ -1656,10 +1057,4 @@ app.get('/elections/:id/results', async (req, res) => {
     });
     res.json({ results: votes });
 });
-if (process.env.NODE_ENV !== 'test') {
-    ensureDatabase();
-    app.listen(port, () => {
-        logger.info('system', `Server listening on port ${port}`);
-    });
-}
-exports.default = app;
+exports.default = router;

--- a/dist/routes/auth.js
+++ b/dist/routes/auth.js
@@ -1,0 +1,104 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.loginAttempts = void 0;
+const express_1 = __importDefault(require("express"));
+const crypto_1 = require("crypto");
+const util_1 = require("util");
+const prisma_1 = __importDefault(require("../prisma"));
+const jwt_1 = require("../jwt");
+const logger = __importStar(require("../logger"));
+const scrypt = (0, util_1.promisify)(crypto_1.scrypt);
+const router = express_1.default.Router();
+exports.loginAttempts = new Map();
+const MAX_LOGIN_ATTEMPTS = 5;
+const LOGIN_WINDOW_MS = 15 * 60 * 1000; // 15 minutes
+const jwtSecret = process.env.JWT_SECRET || 'development-secret';
+router.post('/register', async (req, res) => {
+    const { email, password } = req.body;
+    if (!email || !password) {
+        res.status(400).json({ error: 'Email and password required' });
+        return;
+    }
+    const existing = await prisma_1.default.user.findUnique({ where: { email } });
+    if (existing) {
+        res.status(400).json({ error: 'User already exists' });
+        return;
+    }
+    const salt = (0, crypto_1.randomBytes)(16).toString('hex');
+    const buf = (await scrypt(password, salt, 64));
+    const hashed = `${salt}:${buf.toString('hex')}`;
+    await prisma_1.default.user.create({ data: { email, password: hashed } });
+    logger.info('system', `User registered: ${email}`);
+    res.status(201).json({ message: 'User created' });
+});
+router.post('/login', async (req, res) => {
+    const { email, password } = req.body;
+    if (!email || !password) {
+        res.status(400).json({ error: 'Email and password required' });
+        return;
+    }
+    const now = Date.now();
+    const ip = req.ip || '';
+    const attempt = exports.loginAttempts.get(ip);
+    if (attempt && now - attempt.lastAttempt < LOGIN_WINDOW_MS && attempt.count >= MAX_LOGIN_ATTEMPTS) {
+        logger.warn('system', `Too many login attempts from ${ip}`);
+        res.status(429).json({ error: 'Too many login attempts' });
+        return;
+    }
+    const user = await prisma_1.default.user.findUnique({ where: { email } });
+    if (!user) {
+        const count = attempt && now - attempt.lastAttempt < LOGIN_WINDOW_MS ? attempt.count + 1 : 1;
+        exports.loginAttempts.set(ip, { count, lastAttempt: now });
+        res.status(401).json({ error: 'Invalid credentials' });
+        return;
+    }
+    const [salt, storedHash] = user.password.split(':');
+    const buf = (await scrypt(password, salt, 64));
+    if (buf.toString('hex') !== storedHash) {
+        const count = attempt && now - attempt.lastAttempt < LOGIN_WINDOW_MS ? attempt.count + 1 : 1;
+        exports.loginAttempts.set(ip, { count, lastAttempt: now });
+        res.status(401).json({ error: 'Invalid credentials' });
+        return;
+    }
+    exports.loginAttempts.delete(ip);
+    const token = (0, jwt_1.sign)({ userId: user.id, email: user.email }, jwtSecret);
+    logger.info('system', `User logged in: ${email}`);
+    res.json({ token });
+});
+exports.default = router;

--- a/dist/routes/programYears.js
+++ b/dist/routes/programYears.js
@@ -1,0 +1,153 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const express_1 = __importDefault(require("express"));
+const prisma_1 = __importDefault(require("../prisma"));
+const logger = __importStar(require("../logger"));
+const auth_1 = require("../utils/auth");
+const router = express_1.default.Router();
+router.post('/programs/:programId/years', async (req, res) => {
+    const { programId } = req.params;
+    const caller = req.user;
+    if (!programId) {
+        res.status(400).json({ error: 'programId required' });
+        return;
+    }
+    const isAdmin = await (0, auth_1.isProgramAdmin)(caller.userId, programId);
+    if (!isAdmin) {
+        res.status(403).json({ error: 'Forbidden' });
+        return;
+    }
+    const { year, startDate, endDate, status, notes } = req.body;
+    if (!year) {
+        res.status(400).json({ error: 'year required' });
+        return;
+    }
+    const py = await prisma_1.default.programYear.create({
+        data: {
+            programId,
+            year,
+            startDate: startDate ? new Date(startDate) : undefined,
+            endDate: endDate ? new Date(endDate) : undefined,
+            status: status || 'active',
+            notes,
+        },
+    });
+    logger.info(programId, `Program year ${year} created`);
+    res.status(201).json(py);
+});
+router.get('/programs/:programId/years', async (req, res) => {
+    const { programId } = req.params;
+    const caller = req.user;
+    if (!programId) {
+        res.status(400).json({ error: 'programId required' });
+        return;
+    }
+    const isMember = await (0, auth_1.isProgramMember)(caller.userId, programId);
+    if (!isMember) {
+        res.status(403).json({ error: 'Forbidden' });
+        return;
+    }
+    const years = await prisma_1.default.programYear.findMany({
+        where: { programId },
+        orderBy: { year: 'desc' },
+    });
+    res.json(years);
+});
+router.get('/program-years/:id', async (req, res) => {
+    const { id } = req.params;
+    const caller = req.user;
+    const py = await prisma_1.default.programYear.findUnique({ where: { id: Number(id) } });
+    if (!py) {
+        res.status(404).json({ error: 'Not found' });
+        return;
+    }
+    const isMember = await (0, auth_1.isProgramMember)(caller.userId, py.programId);
+    if (!isMember) {
+        res.status(403).json({ error: 'Forbidden' });
+        return;
+    }
+    res.json(py);
+});
+router.put('/program-years/:id', async (req, res) => {
+    const { id } = req.params;
+    const caller = req.user;
+    const py = await prisma_1.default.programYear.findUnique({ where: { id: Number(id) } });
+    if (!py) {
+        res.status(404).json({ error: 'Not found' });
+        return;
+    }
+    const isAdmin = await (0, auth_1.isProgramAdmin)(caller.userId, py.programId);
+    if (!isAdmin) {
+        res.status(403).json({ error: 'Forbidden' });
+        return;
+    }
+    const { startDate, endDate, status, notes } = req.body;
+    const updated = await prisma_1.default.programYear.update({
+        where: { id: Number(id) },
+        data: {
+            startDate: startDate ? new Date(startDate) : undefined,
+            endDate: endDate ? new Date(endDate) : undefined,
+            status,
+            notes,
+        },
+    });
+    logger.info(py.programId, `Program year ${py.year} updated`);
+    res.json(updated);
+});
+router.delete('/program-years/:id', async (req, res) => {
+    const { id } = req.params;
+    const caller = req.user;
+    const py = await prisma_1.default.programYear.findUnique({ where: { id: Number(id) } });
+    if (!py) {
+        res.status(404).json({ error: 'Not found' });
+        return;
+    }
+    const isAdmin = await (0, auth_1.isProgramAdmin)(caller.userId, py.programId);
+    if (!isAdmin) {
+        res.status(403).json({ error: 'Forbidden' });
+        return;
+    }
+    const updated = await prisma_1.default.programYear.update({
+        where: { id: Number(id) },
+        data: { status: 'archived' },
+    });
+    logger.info(py.programId, `Program year ${py.year} archived`);
+    res.json(updated);
+});
+exports.default = router;

--- a/dist/routes/programs.js
+++ b/dist/routes/programs.js
@@ -1,0 +1,341 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const express_1 = __importDefault(require("express"));
+const prisma_1 = __importDefault(require("../prisma"));
+const logger = __importStar(require("../logger"));
+const auth_1 = require("../utils/auth");
+const router = express_1.default.Router();
+router.post('/programs', async (req, res) => {
+    const user = req.user;
+    const { name, year, config } = req.body;
+    if (!name || !year) {
+        res.status(400).json({ error: 'name and year required' });
+        return;
+    }
+    const program = await prisma_1.default.program.create({
+        data: {
+            name,
+            year,
+            config,
+            createdBy: { connect: { id: user.userId } },
+        },
+    });
+    await prisma_1.default.programAssignment.create({
+        data: { userId: user.userId, programId: program.id, role: 'admin' },
+    });
+    logger.info(program.id, `Program created by ${user.email}`);
+    res.status(201).json({
+        id: program.id,
+        name: program.name,
+        year: program.year,
+        createdBy: user.userId,
+        roleAssigned: 'admin',
+    });
+});
+router.get('/programs', async (_req, res) => {
+    const programs = await prisma_1.default.program.findMany();
+    res.json(programs);
+});
+router.post('/programs/:programId/users', async (req, res) => {
+    const { programId } = req.params;
+    const caller = req.user;
+    if (!programId) {
+        res.status(400).json({ error: 'programId required' });
+        return;
+    }
+    const isAdmin = await (0, auth_1.isProgramAdmin)(caller.userId, programId);
+    if (!isAdmin) {
+        res.status(403).json({ error: 'Forbidden' });
+        return;
+    }
+    const { userId, role } = req.body;
+    if (!userId || !role) {
+        res.status(400).json({ error: 'userId and role required' });
+        return;
+    }
+    await prisma_1.default.programAssignment.create({
+        data: { userId, programId, role },
+    });
+    logger.info(programId, `User ${userId} assigned role ${role}`);
+    res.status(201).json({
+        programId,
+        userId,
+        role,
+        status: 'assigned',
+    });
+});
+router.get('/programs/:programId/users', async (req, res) => {
+    const { programId } = req.params;
+    const caller = req.user;
+    if (!programId) {
+        res.status(400).json({ error: 'programId required' });
+        return;
+    }
+    const isAdmin = await (0, auth_1.isProgramAdmin)(caller.userId, programId);
+    if (!isAdmin) {
+        res.status(403).json({ error: 'Forbidden' });
+        return;
+    }
+    const assignments = await prisma_1.default.programAssignment.findMany({
+        where: { programId },
+        select: { userId: true, role: true },
+    });
+    logger.info(programId, `Listed users for program`);
+    res.json(assignments);
+});
+router.post('/programs/:programId/years', async (req, res) => {
+    const { programId } = req.params;
+    const caller = req.user;
+    if (!programId) {
+        res.status(400).json({ error: 'programId required' });
+        return;
+    }
+    const isAdmin = await (0, auth_1.isProgramAdmin)(caller.userId, programId);
+    if (!isAdmin) {
+        res.status(403).json({ error: 'Forbidden' });
+        return;
+    }
+    const { year, startDate, endDate, status, notes } = req.body;
+    if (!year) {
+        res.status(400).json({ error: 'year required' });
+        return;
+    }
+    const py = await prisma_1.default.programYear.create({
+        data: {
+            programId,
+            year,
+            startDate: startDate ? new Date(startDate) : undefined,
+            endDate: endDate ? new Date(endDate) : undefined,
+            status: status || 'active',
+            notes,
+        },
+    });
+    logger.info(programId, `Program year ${year} created`);
+    res.status(201).json(py);
+});
+router.get('/programs/:programId/years', async (req, res) => {
+    const { programId } = req.params;
+    const caller = req.user;
+    if (!programId) {
+        res.status(400).json({ error: 'programId required' });
+        return;
+    }
+    const isMember = await (0, auth_1.isProgramMember)(caller.userId, programId);
+    if (!isMember) {
+        res.status(403).json({ error: 'Forbidden' });
+        return;
+    }
+    const years = await prisma_1.default.programYear.findMany({
+        where: { programId },
+        orderBy: { year: 'desc' },
+    });
+    res.json(years);
+});
+router.get('/program-years/:id', async (req, res) => {
+    const { id } = req.params;
+    const caller = req.user;
+    const py = await prisma_1.default.programYear.findUnique({ where: { id: Number(id) } });
+    if (!py) {
+        res.status(404).json({ error: 'Not found' });
+        return;
+    }
+    const isMember = await (0, auth_1.isProgramMember)(caller.userId, py.programId);
+    if (!isMember) {
+        res.status(403).json({ error: 'Forbidden' });
+        return;
+    }
+    res.json(py);
+});
+router.put('/program-years/:id', async (req, res) => {
+    const { id } = req.params;
+    const caller = req.user;
+    const py = await prisma_1.default.programYear.findUnique({ where: { id: Number(id) } });
+    if (!py) {
+        res.status(404).json({ error: 'Not found' });
+        return;
+    }
+    const isAdmin = await (0, auth_1.isProgramAdmin)(caller.userId, py.programId);
+    if (!isAdmin) {
+        res.status(403).json({ error: 'Forbidden' });
+        return;
+    }
+    const { startDate, endDate, status, notes } = req.body;
+    const updated = await prisma_1.default.programYear.update({
+        where: { id: Number(id) },
+        data: {
+            startDate: startDate ? new Date(startDate) : undefined,
+            endDate: endDate ? new Date(endDate) : undefined,
+            status,
+            notes,
+        },
+    });
+    logger.info(py.programId, `Program year ${py.year} updated`);
+    res.json(updated);
+});
+router.delete('/program-years/:id', async (req, res) => {
+    const { id } = req.params;
+    const caller = req.user;
+    const py = await prisma_1.default.programYear.findUnique({ where: { id: Number(id) } });
+    if (!py) {
+        res.status(404).json({ error: 'Not found' });
+        return;
+    }
+    const isAdmin = await (0, auth_1.isProgramAdmin)(caller.userId, py.programId);
+    if (!isAdmin) {
+        res.status(403).json({ error: 'Forbidden' });
+        return;
+    }
+    const updated = await prisma_1.default.programYear.update({
+        where: { id: Number(id) },
+        data: { status: 'archived' },
+    });
+    logger.info(py.programId, `Program year ${py.year} archived`);
+    res.json(updated);
+});
+router.get('/user-programs/:username', auth_1.getUserPrograms);
+router.get('/programs/:id', async (req, res) => {
+    const { id } = req.params;
+    const caller = req.user;
+    const program = await prisma_1.default.program.findUnique({ where: { id } });
+    if (!program) {
+        res.status(404).json({ error: 'Not found' });
+        return;
+    }
+    const member = await (0, auth_1.isProgramMember)(caller.userId, id);
+    if (!member) {
+        res.status(403).json({ error: 'Forbidden' });
+        return;
+    }
+    res.json(program);
+});
+router.get('/programs/:id/branding', async (req, res) => {
+    const { id } = req.params;
+    const caller = req.user;
+    const program = await prisma_1.default.program.findUnique({ where: { id } });
+    if (!program) {
+        res.status(404).json({ error: 'Not found' });
+        return;
+    }
+    const member = await (0, auth_1.isProgramMember)(caller.userId, id);
+    if (!member) {
+        res.status(403).json({ error: 'Forbidden' });
+        return;
+    }
+    const branding = {
+        brandingLogoUrl: program.brandingLogoUrl,
+        brandingPrimaryColor: program.brandingPrimaryColor,
+        brandingSecondaryColor: program.brandingSecondaryColor,
+        welcomeMessage: program.welcomeMessage,
+        contactEmail: program.contactEmail,
+        contactPhone: program.contactPhone,
+        socialLinks: program.socialLinks,
+    };
+    res.json(branding);
+});
+router.put('/programs/:id/branding', async (req, res) => {
+    const { id } = req.params;
+    const caller = req.user;
+    const program = await prisma_1.default.program.findUnique({ where: { id } });
+    if (!program) {
+        res.status(404).json({ error: 'Not found' });
+        return;
+    }
+    const isAdmin = await (0, auth_1.isProgramAdmin)(caller.userId, id);
+    if (!isAdmin) {
+        res.status(403).json({ error: 'Forbidden' });
+        return;
+    }
+    const { brandingLogoUrl, brandingPrimaryColor, brandingSecondaryColor, welcomeMessage, contactEmail, contactPhone, socialLinks, } = req.body;
+    const updated = await prisma_1.default.program.update({
+        where: { id },
+        data: {
+            brandingLogoUrl,
+            brandingPrimaryColor,
+            brandingSecondaryColor,
+            welcomeMessage,
+            contactEmail,
+            contactPhone,
+            socialLinks,
+        },
+    });
+    logger.info(id, `Branding updated by ${caller.email}`);
+    res.json(updated);
+});
+router.put('/programs/:id', async (req, res) => {
+    const { id } = req.params;
+    const caller = req.user;
+    const program = await prisma_1.default.program.findUnique({ where: { id } });
+    if (!program) {
+        res.status(404).json({ error: 'Not found' });
+        return;
+    }
+    const isAdmin = await (0, auth_1.isProgramAdmin)(caller.userId, id);
+    if (!isAdmin) {
+        res.status(403).json({ error: 'Forbidden' });
+        return;
+    }
+    const { name, year, config, status } = req.body;
+    const updated = await prisma_1.default.program.update({
+        where: { id },
+        data: { name, year, config, status },
+    });
+    logger.info(id, `Program updated by ${caller.email}`);
+    res.json(updated);
+});
+router.delete('/programs/:id', async (req, res) => {
+    const { id } = req.params;
+    const caller = req.user;
+    const program = await prisma_1.default.program.findUnique({ where: { id } });
+    if (!program) {
+        res.status(404).json({ error: 'Not found' });
+        return;
+    }
+    const isAdmin = await (0, auth_1.isProgramAdmin)(caller.userId, id);
+    if (!isAdmin) {
+        res.status(403).json({ error: 'Forbidden' });
+        return;
+    }
+    const updated = await prisma_1.default.program.update({
+        where: { id },
+        data: { status: 'retired' },
+    });
+    logger.info(id, `Program retired by ${caller.email}`);
+    res.json(updated);
+});
+exports.default = router;

--- a/dist/routes/system.js
+++ b/dist/routes/system.js
@@ -1,0 +1,193 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.swaggerDoc = void 0;
+const express_1 = __importDefault(require("express"));
+const fs_1 = require("fs");
+const path_1 = __importDefault(require("path"));
+const swagger_ui_express_1 = __importDefault(require("swagger-ui-express"));
+const yaml_1 = __importDefault(require("yaml"));
+const prisma_1 = __importDefault(require("../prisma"));
+const logger = __importStar(require("../logger"));
+const router = express_1.default.Router();
+const openApiPath = path_1.default.join(__dirname, '..', 'openapi.yaml');
+const swaggerDoc = yaml_1.default.parse((0, fs_1.readFileSync)(openApiPath, 'utf8'));
+exports.swaggerDoc = swaggerDoc;
+const port = process.env.PORT || 3000;
+if (process.env.NODE_ENV !== 'production') {
+    swaggerDoc.servers = [{ url: `http://localhost:${port}` }];
+}
+router.get('/docs/swagger.json', (_req, res) => {
+    res.json(swaggerDoc);
+});
+router.get('/docs/swagger-ui-custom.js', (_req, res) => {
+    res.sendFile(path_1.default.join(__dirname, '..', 'swagger-ui-custom.js'));
+});
+router.use('/docs', swagger_ui_express_1.default.serve, swagger_ui_express_1.default.setup(swaggerDoc, { customJs: 'swagger-ui-custom.js' }));
+router.get('/health', async (_req, res) => {
+    logger.info('system', 'Serving /health');
+    let dbStatus = 'ok';
+    try {
+        await prisma_1.default.$queryRaw `SELECT 1`;
+    }
+    catch (err) {
+        logger.error('system', 'Database check failed', err);
+        dbStatus = 'error';
+    }
+    res.json({ status: 'ok', database: dbStatus });
+});
+router.post('/logs', (req, res) => {
+    const { programId, level, message, error, source } = req.body;
+    if (!programId || !level || !message) {
+        res.status(400).json({ error: 'programId, level, and message required' });
+        return;
+    }
+    const lvl = level;
+    if (!['debug', 'info', 'warn', 'error'].includes(lvl)) {
+        res.status(400).json({ error: 'Invalid level' });
+        return;
+    }
+    const src = source || 'client';
+    switch (lvl) {
+        case 'debug':
+            logger.debug(programId, message, src);
+            break;
+        case 'info':
+            logger.info(programId, message, src);
+            break;
+        case 'warn':
+            logger.warn(programId, message, src);
+            break;
+        case 'error':
+            logger.error(programId, message, error, src);
+            break;
+    }
+    res.status(204).send();
+});
+router.get('/logs', async (req, res) => {
+    const { programId, level, source, dateFrom, dateTo, search, page = '1', pageSize = '50', } = req.query;
+    if (level && !['debug', 'info', 'warn', 'error'].includes(level)) {
+        res.status(400).json({ error: 'Invalid level' });
+        return;
+    }
+    let p = parseInt(page, 10);
+    if (isNaN(p) || p < 1)
+        p = 1;
+    let size = parseInt(pageSize, 10);
+    if (isNaN(size) || size < 1)
+        size = 50;
+    if (size > 100)
+        size = 100;
+    const where = {};
+    if (programId)
+        where.programId = programId;
+    if (level)
+        where.level = level;
+    if (source)
+        where.source = source;
+    if (dateFrom || dateTo) {
+        where.timestamp = {};
+        if (dateFrom)
+            where.timestamp.gte = new Date(dateFrom);
+        if (dateTo)
+            where.timestamp.lte = new Date(dateTo);
+    }
+    if (search) {
+        const contains = { contains: search, mode: 'insensitive' };
+        where.OR = [{ message: contains }, { error: contains }, { source: contains }];
+    }
+    const total = await prisma_1.default.log.count({ where });
+    const logs = await prisma_1.default.log.findMany({
+        where,
+        orderBy: { timestamp: 'desc' },
+        skip: (p - 1) * size,
+        take: size,
+    });
+    res.json({ logs, page: p, pageSize: size, total });
+});
+router.post('/audit-logs', async (req, res) => {
+    const { tableName, recordId, userId, action, changes } = req.body;
+    if (!tableName || recordId === undefined || !userId || !action) {
+        res.status(400).json({ error: 'tableName, recordId, userId and action required' });
+        return;
+    }
+    const log = await prisma_1.default.auditLog.create({
+        data: {
+            tableName,
+            recordId: String(recordId),
+            userId,
+            action,
+            changes,
+        },
+    });
+    res.status(201).json(log);
+});
+router.get('/audit-logs', async (req, res) => {
+    const { tableName, recordId, userId, dateFrom, dateTo, page = '1', pageSize = '50', } = req.query;
+    let p = parseInt(page, 10);
+    if (isNaN(p) || p < 1)
+        p = 1;
+    let size = parseInt(pageSize, 10);
+    if (isNaN(size) || size < 1)
+        size = 50;
+    if (size > 100)
+        size = 100;
+    const where = {};
+    if (tableName)
+        where.tableName = tableName;
+    if (recordId)
+        where.recordId = recordId;
+    if (userId)
+        where.userId = Number(userId);
+    if (dateFrom || dateTo) {
+        where.timestamp = {};
+        if (dateFrom)
+            where.timestamp.gte = new Date(dateFrom);
+        if (dateTo)
+            where.timestamp.lte = new Date(dateTo);
+    }
+    const total = await prisma_1.default.auditLog.count({ where });
+    const logs = await prisma_1.default.auditLog.findMany({
+        where,
+        orderBy: { timestamp: 'desc' },
+        skip: (p - 1) * size,
+        take: size,
+    });
+    res.json({ auditLogs: logs, page: p, pageSize: size, total });
+});
+exports.default = router;

--- a/dist/routes/users.js
+++ b/dist/routes/users.js
@@ -1,0 +1,10 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const express_1 = __importDefault(require("express"));
+const auth_1 = require("../utils/auth");
+const router = express_1.default.Router();
+router.get('/user-programs/:username', auth_1.getUserPrograms);
+exports.default = router;

--- a/dist/utils/auth.js
+++ b/dist/utils/auth.js
@@ -1,0 +1,80 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.isProgramAdmin = isProgramAdmin;
+exports.isProgramMember = isProgramMember;
+exports.getUserPrograms = getUserPrograms;
+const prisma_1 = __importDefault(require("../prisma"));
+const logger = __importStar(require("../logger"));
+async function isProgramAdmin(userId, programId) {
+    const assignment = await prisma_1.default.programAssignment.findFirst({
+        where: { userId, programId },
+    });
+    return assignment?.role === 'admin';
+}
+async function isProgramMember(userId, programId) {
+    const assignment = await prisma_1.default.programAssignment.findFirst({
+        where: { userId, programId },
+    });
+    return Boolean(assignment);
+}
+async function getUserPrograms(req, res) {
+    const { username } = req.params;
+    if (!username) {
+        res.status(400).json({ error: 'Username required' });
+        return;
+    }
+    const user = await prisma_1.default.user.findUnique({ where: { email: username } });
+    if (!user) {
+        res.status(404).json({ error: 'User not found' });
+        return;
+    }
+    const assignments = await prisma_1.default.programAssignment.findMany({
+        where: { userId: user.id },
+        include: { program: true },
+    });
+    const programs = assignments.map((a) => ({
+        programId: a.program.id,
+        programName: a.program.name,
+        role: a.role,
+    }));
+    programs.forEach((p) => {
+        logger.info(p.programId, `Program lookup for ${user.email}`);
+    });
+    res.json({ username: user.email, programs });
+}

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,0 +1,72 @@
+import express from 'express';
+import cors, { CorsOptions } from 'cors';
+import { execSync } from 'child_process';
+import { verify } from './jwt';
+import * as logger from './logger';
+import authRoutes, { loginAttempts } from './routes/auth';
+import systemRoutes, { swaggerDoc } from './routes/system';
+import apiRoutes from './routes/api';
+import programsRoutes from "./routes/programs";
+import programYearsRoutes from "./routes/programYears";
+import usersRoutes from "./routes/users";
+
+const app = express();
+const corsOptions: CorsOptions = { origin: true, credentials: true };
+app.use(cors(corsOptions));
+app.use(express.json());
+
+app.use((req, _res, next) => {
+  const programId = (req as any).user?.programId || 'system';
+  logger.info(programId, `${req.method} ${req.path}`);
+  next();
+});
+
+const jwtSecret = process.env.JWT_SECRET || 'development-secret';
+
+app.use((req, res, next) => {
+  if (
+    req.path === '/login' ||
+    req.path === '/register' ||
+    req.path.startsWith('/docs')
+  ) {
+    return next();
+  }
+  const auth = req.headers.authorization;
+  if (!auth || !auth.startsWith('Bearer ')) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+  const token = auth.slice(7);
+  try {
+    (req as any).user = verify(token, jwtSecret);
+    next();
+  } catch {
+    res.status(401).json({ error: 'Unauthorized' });
+  }
+});
+
+export function ensureDatabase() {
+  try {
+    logger.info('system', 'Running database synchronization');
+    execSync('npx prisma db push', { stdio: 'inherit' });
+  } catch (err) {
+    logger.error('system', 'Database synchronization failed', err);
+  }
+}
+
+app.use(authRoutes);
+app.use(systemRoutes);
+app.use(programsRoutes);
+app.use(programYearsRoutes);
+app.use(usersRoutes);
+app.use(apiRoutes);
+
+const port = process.env.PORT || 3000;
+if (process.env.NODE_ENV !== 'test') {
+  ensureDatabase();
+  app.listen(port, () => {
+    logger.info('system', `Server listening on port ${port}`);
+  });
+}
+
+export { app as default, loginAttempts, swaggerDoc };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,4 @@
-import app, { loginAttempts, ensureDatabase, swaggerDoc, getUserPrograms } from './main';
-export { app as default, loginAttempts, ensureDatabase, swaggerDoc, getUserPrograms };
+import app, { loginAttempts, swaggerDoc, ensureDatabase } from './app';
+export default app;
+export { loginAttempts, ensureDatabase, swaggerDoc };
+export { getUserPrograms } from './utils/auth';

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -1,738 +1,11 @@
-/* istanbul ignore file */
 import express from 'express';
-import cors, { CorsOptions } from 'cors';
-import { readFileSync } from 'fs';
-import path from 'path';
-import { execSync } from 'child_process';
-import swaggerUi from 'swagger-ui-express';
-import yaml from 'yaml';
-import { randomBytes, scrypt as _scrypt } from 'crypto';
-import { promisify } from 'util';
-import prisma from './prisma';
-import { sign, verify } from './jwt';
-import * as logger from './logger';
-
-const scrypt = promisify(_scrypt);
-
-const app = express();
-// Configure CORS to allow credentialed requests
-const corsOptions: CorsOptions = {
-  origin: true,
-  credentials: true,
-};
-app.use(cors(corsOptions));
-app.use(express.json());
-
-app.use((req, _res, next) => {
-  const programId = (req as any).user?.programId || 'system';
-  logger.info(programId, `${req.method} ${req.path}`);
-  next();
-});
-
-const jwtSecret = process.env.JWT_SECRET || 'development-secret';
-
-const loginAttempts = new Map<string, { count: number; lastAttempt: number }>();
-const MAX_LOGIN_ATTEMPTS = 5;
-const LOGIN_WINDOW_MS = 15 * 60 * 1000; // 15 minutes
-
-app.use((req, res, next) => {
-  if (
-    req.path === '/login' ||
-    req.path === '/register' ||
-    req.path.startsWith('/docs')
-  ) {
-    return next();
-  }
-  const auth = req.headers.authorization;
-  if (!auth || !auth.startsWith('Bearer ')) {
-    res.status(401).json({ error: 'Unauthorized' });
-    return;
-  }
-  const token = auth.slice(7);
-  try {
-    (req as any).user = verify(token, jwtSecret);
-    next();
-  } catch {
-    res.status(401).json({ error: 'Unauthorized' });
-  }
-});
-
-function ensureDatabase() {
-  try {
-    logger.info('system', 'Running database synchronization');
-    execSync('npx prisma db push', { stdio: 'inherit' });
-  } catch (err) {
-    logger.error('system', 'Database synchronization failed', err);
-  }
-}
-
-// Load OpenAPI spec
-const openApiPath = path.join(__dirname, 'openapi.yaml');
-const openApiDoc = yaml.parse(readFileSync(openApiPath, 'utf8'));
-
-app.get('/docs/swagger.json', (_req, res) => {
-  res.json(openApiDoc);
-});
-
-// Override server URL when not in production so Swagger points to the local API
-const port = process.env.PORT || 3000;
-if (process.env.NODE_ENV !== 'production') {
-  openApiDoc.servers = [{ url: `http://localhost:${port}` }];
-}
-
-app.get('/docs/swagger-ui-custom.js', (_req, res) => {
-  res.sendFile(path.join(__dirname, 'swagger-ui-custom.js'));
-});
-
-const docsOptions = {
-  customJs: 'swagger-ui-custom.js',
-};
-
-app.use('/docs', swaggerUi.serve, swaggerUi.setup(openApiDoc, docsOptions));
-
-export const swaggerDoc = openApiDoc;
-
-app.post('/register', async (req: express.Request, res: express.Response) => {
-  const { email, password } = req.body as { email?: string; password?: string };
-  if (!email || !password) {
-    res.status(400).json({ error: 'Email and password required' });
-    return;
-  }
-
-  const existing = await prisma.user.findUnique({ where: { email } });
-  if (existing) {
-    res.status(400).json({ error: 'User already exists' });
-    return;
-  }
-
-  const salt = randomBytes(16).toString('hex');
-  const buf = (await scrypt(password, salt, 64)) as Buffer;
-  const hashed = `${salt}:${buf.toString('hex')}`;
-
-  await prisma.user.create({ data: { email, password: hashed } });
-  logger.info('system', `User registered: ${email}`);
-  res.status(201).json({ message: 'User created' });
-  return;
-});
-
-app.post('/login', async (req: express.Request, res: express.Response) => {
-  const { email, password } = req.body as { email?: string; password?: string };
-  if (!email || !password) {
-    res.status(400).json({ error: 'Email and password required' });
-    return;
-  }
-
-  const now = Date.now();
-  const ip = req.ip || '';
-  const attempt = loginAttempts.get(ip);
-  if (attempt && now - attempt.lastAttempt < LOGIN_WINDOW_MS && attempt.count >= MAX_LOGIN_ATTEMPTS) {
-    logger.warn('system', `Too many login attempts from ${ip}`);
-    res.status(429).json({ error: 'Too many login attempts' });
-    return;
-  }
-
-  const user = await prisma.user.findUnique({ where: { email } });
-  if (!user) {
-    const count = attempt && now - attempt.lastAttempt < LOGIN_WINDOW_MS ? attempt.count + 1 : 1;
-    loginAttempts.set(ip, { count, lastAttempt: now });
-    res.status(401).json({ error: 'Invalid credentials' });
-    return;
-  }
-
-  const [salt, storedHash] = user.password.split(':');
-  const buf = (await scrypt(password, salt, 64)) as Buffer;
-  if (buf.toString('hex') !== storedHash) {
-    const count = attempt && now - attempt.lastAttempt < LOGIN_WINDOW_MS ? attempt.count + 1 : 1;
-    loginAttempts.set(ip, { count, lastAttempt: now });
-    res.status(401).json({ error: 'Invalid credentials' });
-    return;
-  }
-
-  loginAttempts.delete(ip);
-
-  const token = sign({ userId: user.id, email: user.email }, jwtSecret);
-  logger.info('system', `User logged in: ${email}`);
-  res.json({ token });
-  return;
-});
-
-app.get('/health', async (_req, res) => {
-  logger.info('system', 'Serving /health');
-  let dbStatus = 'ok';
-  try {
-    await prisma.$queryRaw`SELECT 1`;
-  } catch (err) {
-    logger.error('system', 'Database check failed', err);
-    dbStatus = 'error';
-  }
-  res.json({ status: 'ok', database: dbStatus });
-});
-
-app.post('/logs', (req: express.Request, res: express.Response) => {
-  const { programId, level, message, error, source } = req.body as {
-    programId?: string;
-    level?: string;
-    message?: string;
-    error?: string;
-    source?: string;
-  };
-  if (!programId || !level || !message) {
-    res.status(400).json({ error: 'programId, level, and message required' });
-    return;
-  }
-  const lvl = level as string;
-  if (!['debug', 'info', 'warn', 'error'].includes(lvl)) {
-    res.status(400).json({ error: 'Invalid level' });
-    return;
-  }
-  const src = source || 'client';
-  switch (lvl) {
-    case 'debug':
-      logger.debug(programId, message, src);
-      break;
-    case 'info':
-      logger.info(programId, message, src);
-      break;
-    case 'warn':
-      logger.warn(programId, message, src);
-      break;
-    case 'error':
-      logger.error(programId, message, error, src);
-      break;
-  }
-  res.status(204).send();
-});
-
-app.get('/logs', async (req: express.Request, res: express.Response) => {
-  const {
-    programId,
-    level,
-    source,
-    dateFrom,
-    dateTo,
-    search,
-    page = '1',
-    pageSize = '50',
-  } = req.query as {
-    programId?: string;
-    level?: string;
-    source?: string;
-    dateFrom?: string;
-    dateTo?: string;
-    search?: string;
-    page?: string;
-    pageSize?: string;
-  };
-
-  if (level && !['debug', 'info', 'warn', 'error'].includes(level)) {
-    res.status(400).json({ error: 'Invalid level' });
-    return;
-  }
-
-  let p = parseInt(page, 10);
-  if (isNaN(p) || p < 1) p = 1;
-  let size = parseInt(pageSize, 10);
-  if (isNaN(size) || size < 1) size = 50;
-  if (size > 100) size = 100;
-
-  const where: any = {};
-  if (programId) where.programId = programId;
-  if (level) where.level = level;
-  if (source) where.source = source;
-  if (dateFrom || dateTo) {
-    where.timestamp = {} as any;
-    if (dateFrom) (where.timestamp as any).gte = new Date(dateFrom);
-    if (dateTo) (where.timestamp as any).lte = new Date(dateTo);
-  }
-
-  if (search) {
-    const contains = { contains: search, mode: 'insensitive' as const };
-    where.OR = [{ message: contains }, { error: contains }, { source: contains }];
-  }
-
-  const total = await prisma.log.count({ where });
-  const logs = await prisma.log.findMany({
-    where,
-    orderBy: { timestamp: 'desc' },
-    skip: (p - 1) * size,
-    take: size,
-  });
-
-  res.json({ logs, page: p, pageSize: size, total });
-});
-
-app.post('/audit-logs', async (req: express.Request, res: express.Response) => {
-  const { tableName, recordId, userId, action, changes } = req.body as {
-    tableName?: string;
-    recordId?: string | number;
-    userId?: number;
-    action?: string;
-    changes?: any;
-  };
-  if (!tableName || recordId === undefined || !userId || !action) {
-    res
-      .status(400)
-      .json({ error: 'tableName, recordId, userId and action required' });
-    return;
-  }
-  const log = await prisma.auditLog.create({
-    data: {
-      tableName,
-      recordId: String(recordId),
-      userId,
-      action,
-      changes,
-    },
-  });
-  res.status(201).json(log);
-});
-
-app.get('/audit-logs', async (req: express.Request, res: express.Response) => {
-  const {
-    tableName,
-    recordId,
-    userId,
-    dateFrom,
-    dateTo,
-    page = '1',
-    pageSize = '50',
-  } = req.query as {
-    tableName?: string;
-    recordId?: string;
-    userId?: string;
-    dateFrom?: string;
-    dateTo?: string;
-    page?: string;
-    pageSize?: string;
-  };
-
-  let p = parseInt(page, 10);
-  if (isNaN(p) || p < 1) p = 1;
-  let size = parseInt(pageSize, 10);
-  if (isNaN(size) || size < 1) size = 50;
-  if (size > 100) size = 100;
-
-  const where: any = {};
-  if (tableName) where.tableName = tableName;
-  if (recordId) where.recordId = recordId;
-  if (userId) where.userId = Number(userId);
-  if (dateFrom || dateTo) {
-    where.timestamp = {} as any;
-    if (dateFrom) (where.timestamp as any).gte = new Date(dateFrom);
-    if (dateTo) (where.timestamp as any).lte = new Date(dateTo);
-  }
-
-  const total = await prisma.auditLog.count({ where });
-  const logs = await prisma.auditLog.findMany({
-    where,
-    orderBy: { timestamp: 'desc' },
-    skip: (p - 1) * size,
-    take: size,
-  });
-
-  res.json({ auditLogs: logs, page: p, pageSize: size, total });
-});
-
-export async function getUserPrograms(
-  req: express.Request,
-  res: express.Response
-) {
-  const { username } = req.params as { username?: string };
-  if (!username) {
-    res.status(400).json({ error: 'Username required' });
-    return;
-  }
-
-  const user = await prisma.user.findUnique({ where: { email: username } });
-  if (!user) {
-    res.status(404).json({ error: 'User not found' });
-    return;
-  }
-
-  const assignments = await prisma.programAssignment.findMany({
-    where: { userId: user.id },
-    include: { program: true },
-  });
-  const programs = assignments.map((a: any) => ({
-    programId: a.program.id,
-    programName: a.program.name,
-    role: a.role,
-  }));
-  programs.forEach((p: any) => {
-    logger.info(p.programId, `Program lookup for ${user.email}`);
-  });
-  res.json({ username: user.email, programs });
-}
+import prisma from '../prisma';
+import * as logger from '../logger';
+import { isProgramAdmin, isProgramMember } from "../utils/auth";
+const router = express.Router();
 
 
-async function isProgramAdmin(userId: number, programId: string) {
-  const assignment = await prisma.programAssignment.findFirst({
-    where: { userId, programId },
-  });
-  return assignment?.role === 'admin';
-}
-
-async function isProgramMember(userId: number, programId: string) {
-  const assignment = await prisma.programAssignment.findFirst({
-    where: { userId, programId },
-  });
-  return Boolean(assignment);
-}
-
-app.post('/programs', async (req: express.Request, res: express.Response) => {
-  const user = (req as any).user as { userId: number; email: string };
-  const { name, year, config } = req.body as {
-    name?: string;
-    year?: number;
-    config?: any;
-  };
-  if (!name || !year) {
-    res.status(400).json({ error: 'name and year required' });
-    return;
-  }
-  const program = await prisma.program.create({
-    data: {
-      name,
-      year,
-      config,
-      createdBy: { connect: { id: user.userId } },
-    },
-  });
-  await prisma.programAssignment.create({
-    data: { userId: user.userId, programId: program.id, role: 'admin' },
-  });
-  logger.info(program.id, `Program created by ${user.email}`);
-  res.status(201).json({
-    id: program.id,
-    name: program.name,
-    year: program.year,
-    createdBy: user.userId,
-    roleAssigned: 'admin',
-  });
-});
-
-app.get('/programs', async (_req: express.Request, res: express.Response) => {
-  const programs = await prisma.program.findMany();
-  res.json(programs);
-});
-
-
-app.post(
-  '/programs/:programId/users',
-  async (req: express.Request, res: express.Response) => {
-    const { programId } = req.params as { programId?: string };
-    const caller = (req as any).user as { userId: number; email: string };
-    if (!programId) {
-      res.status(400).json({ error: 'programId required' });
-      return;
-    }
-    const isAdmin = await isProgramAdmin(caller.userId, programId);
-    if (!isAdmin) {
-      res.status(403).json({ error: 'Forbidden' });
-      return;
-    }
-    const { userId, role } = req.body as { userId?: number; role?: string };
-    if (!userId || !role) {
-      res.status(400).json({ error: 'userId and role required' });
-      return;
-    }
-    await prisma.programAssignment.create({
-      data: { userId, programId, role },
-    });
-    logger.info(programId, `User ${userId} assigned role ${role}`);
-    res.status(201).json({
-      programId,
-      userId,
-      role,
-      status: 'assigned',
-    });
-  },
-);
-
-app.get(
-  '/programs/:programId/users',
-  async (req: express.Request, res: express.Response) => {
-    const { programId } = req.params as { programId?: string };
-    const caller = (req as any).user as { userId: number; email: string };
-    if (!programId) {
-      res.status(400).json({ error: 'programId required' });
-      return;
-    }
-    const isAdmin = await isProgramAdmin(caller.userId, programId);
-    if (!isAdmin) {
-      res.status(403).json({ error: 'Forbidden' });
-      return;
-    }
-    const assignments = await prisma.programAssignment.findMany({
-      where: { programId },
-      select: { userId: true, role: true },
-    });
-    logger.info(programId, `Listed users for program`);
-    res.json(assignments);
-  },
-);
-
-app.post(
-  '/programs/:programId/years',
-  async (req: express.Request, res: express.Response) => {
-    const { programId } = req.params as { programId?: string };
-    const caller = (req as any).user as { userId: number; email: string };
-    if (!programId) {
-      res.status(400).json({ error: 'programId required' });
-      return;
-    }
-    const isAdmin = await isProgramAdmin(caller.userId, programId);
-    if (!isAdmin) {
-      res.status(403).json({ error: 'Forbidden' });
-      return;
-    }
-    const { year, startDate, endDate, status, notes } = req.body as {
-      year?: number;
-      startDate?: string;
-      endDate?: string;
-      status?: string;
-      notes?: string;
-    };
-    if (!year) {
-      res.status(400).json({ error: 'year required' });
-      return;
-    }
-    const py = await prisma.programYear.create({
-      data: {
-        programId,
-        year,
-        startDate: startDate ? new Date(startDate) : undefined,
-        endDate: endDate ? new Date(endDate) : undefined,
-        status: status || 'active',
-        notes,
-      },
-    });
-    logger.info(programId, `Program year ${year} created`);
-    res.status(201).json(py);
-  },
-);
-
-app.get(
-  '/programs/:programId/years',
-  async (req: express.Request, res: express.Response) => {
-    const { programId } = req.params as { programId?: string };
-    const caller = (req as any).user as { userId: number };
-    if (!programId) {
-      res.status(400).json({ error: 'programId required' });
-      return;
-    }
-    const isMember = await isProgramMember(caller.userId, programId);
-    if (!isMember) {
-      res.status(403).json({ error: 'Forbidden' });
-      return;
-    }
-    const years = await prisma.programYear.findMany({
-      where: { programId },
-      orderBy: { year: 'desc' },
-    });
-    res.json(years);
-  },
-);
-
-app.get('/program-years/:id', async (req: express.Request, res: express.Response) => {
-  const { id } = req.params as { id?: string };
-  const caller = (req as any).user as { userId: number };
-  const py = await prisma.programYear.findUnique({ where: { id: Number(id) } });
-  if (!py) {
-    res.status(404).json({ error: 'Not found' });
-    return;
-  }
-  const isMember = await isProgramMember(caller.userId, py.programId);
-  if (!isMember) {
-    res.status(403).json({ error: 'Forbidden' });
-    return;
-  }
-  res.json(py);
-});
-
-app.put('/program-years/:id', async (req: express.Request, res: express.Response) => {
-  const { id } = req.params as { id?: string };
-  const caller = (req as any).user as { userId: number };
-  const py = await prisma.programYear.findUnique({ where: { id: Number(id) } });
-  if (!py) {
-    res.status(404).json({ error: 'Not found' });
-    return;
-  }
-  const isAdmin = await isProgramAdmin(caller.userId, py.programId);
-  if (!isAdmin) {
-    res.status(403).json({ error: 'Forbidden' });
-    return;
-  }
-  const { startDate, endDate, status, notes } = req.body as {
-    startDate?: string;
-    endDate?: string;
-    status?: string;
-    notes?: string;
-  };
-  const updated = await prisma.programYear.update({
-    where: { id: Number(id) },
-    data: {
-      startDate: startDate ? new Date(startDate) : undefined,
-      endDate: endDate ? new Date(endDate) : undefined,
-      status,
-      notes,
-    },
-  });
-  logger.info(py.programId, `Program year ${py.year} updated`);
-  res.json(updated);
-});
-
-app.delete('/program-years/:id', async (req: express.Request, res: express.Response) => {
-  const { id } = req.params as { id?: string };
-  const caller = (req as any).user as { userId: number };
-  const py = await prisma.programYear.findUnique({ where: { id: Number(id) } });
-  if (!py) {
-    res.status(404).json({ error: 'Not found' });
-    return;
-  }
-  const isAdmin = await isProgramAdmin(caller.userId, py.programId);
-  if (!isAdmin) {
-    res.status(403).json({ error: 'Forbidden' });
-    return;
-  }
-  const updated = await prisma.programYear.update({
-    where: { id: Number(id) },
-    data: { status: 'archived' },
-  });
-  logger.info(py.programId, `Program year ${py.year} archived`);
-  res.json(updated);
-});
-
-app.get('/user-programs/:username', getUserPrograms);
-
-app.get('/programs/:id', async (req: express.Request, res: express.Response) => {
-  const { id } = req.params as { id?: string };
-  const caller = (req as any).user as { userId: number };
-  const program = await prisma.program.findUnique({ where: { id } });
-  if (!program) {
-    res.status(404).json({ error: 'Not found' });
-    return;
-  }
-  const member = await isProgramMember(caller.userId, id!);
-  if (!member) {
-    res.status(403).json({ error: 'Forbidden' });
-    return;
-  }
-  res.json(program);
-});
-
-app.get('/programs/:id/branding', async (req: express.Request, res: express.Response) => {
-  const { id } = req.params as { id?: string };
-  const caller = (req as any).user as { userId: number };
-  const program = await prisma.program.findUnique({ where: { id } });
-  if (!program) {
-    res.status(404).json({ error: 'Not found' });
-    return;
-  }
-  const member = await isProgramMember(caller.userId, id!);
-  if (!member) {
-    res.status(403).json({ error: 'Forbidden' });
-    return;
-  }
-  const branding = {
-    brandingLogoUrl: program.brandingLogoUrl,
-    brandingPrimaryColor: program.brandingPrimaryColor,
-    brandingSecondaryColor: program.brandingSecondaryColor,
-    welcomeMessage: program.welcomeMessage,
-    contactEmail: program.contactEmail,
-    contactPhone: program.contactPhone,
-    socialLinks: program.socialLinks,
-  };
-  res.json(branding);
-});
-
-app.put('/programs/:id/branding', async (req: express.Request, res: express.Response) => {
-  const { id } = req.params as { id?: string };
-  const caller = (req as any).user as { userId: number; email: string };
-  const program = await prisma.program.findUnique({ where: { id } });
-  if (!program) {
-    res.status(404).json({ error: 'Not found' });
-    return;
-  }
-  const isAdmin = await isProgramAdmin(caller.userId, id!);
-  if (!isAdmin) {
-    res.status(403).json({ error: 'Forbidden' });
-    return;
-  }
-  const {
-    brandingLogoUrl,
-    brandingPrimaryColor,
-    brandingSecondaryColor,
-    welcomeMessage,
-    contactEmail,
-    contactPhone,
-    socialLinks,
-  } = req.body as any;
-  const updated = await prisma.program.update({
-    where: { id },
-    data: {
-      brandingLogoUrl,
-      brandingPrimaryColor,
-      brandingSecondaryColor,
-      welcomeMessage,
-      contactEmail,
-      contactPhone,
-      socialLinks,
-    },
-  });
-  logger.info(id!, `Branding updated by ${caller.email}`);
-  res.json(updated);
-});
-
-app.put('/programs/:id', async (req: express.Request, res: express.Response) => {
-  const { id } = req.params as { id?: string };
-  const caller = (req as any).user as { userId: number; email: string };
-  const program = await prisma.program.findUnique({ where: { id } });
-  if (!program) {
-    res.status(404).json({ error: 'Not found' });
-    return;
-  }
-  const isAdmin = await isProgramAdmin(caller.userId, id!);
-  if (!isAdmin) {
-    res.status(403).json({ error: 'Forbidden' });
-    return;
-  }
-  const { name, year, config, status } = req.body as {
-    name?: string;
-    year?: number;
-    config?: any;
-    status?: string;
-  };
-  const updated = await prisma.program.update({
-    where: { id },
-    data: { name, year, config, status },
-  });
-  logger.info(id!, `Program updated by ${caller.email}`);
-  res.json(updated);
-});
-
-app.delete('/programs/:id', async (req: express.Request, res: express.Response) => {
-  const { id } = req.params as { id?: string };
-  const caller = (req as any).user as { userId: number; email: string };
-  const program = await prisma.program.findUnique({ where: { id } });
-  if (!program) {
-    res.status(404).json({ error: 'Not found' });
-    return;
-  }
-  const isAdmin = await isProgramAdmin(caller.userId, id!);
-  if (!isAdmin) {
-    res.status(403).json({ error: 'Forbidden' });
-    return;
-  }
-  const updated = await prisma.program.update({
-    where: { id },
-    data: { status: 'retired' },
-  });
-  logger.info(id!, `Program retired by ${caller.email}`);
-  res.json(updated);
-});
-
-app.post(
+router.post(
   '/programs/:programId/grouping-types',
   async (req: express.Request, res: express.Response) => {
     const { programId } = req.params as { programId?: string };
@@ -779,7 +52,7 @@ app.post(
   },
 );
 
-app.get(
+router.get(
   '/programs/:programId/grouping-types',
   async (req: express.Request, res: express.Response) => {
     const { programId } = req.params as { programId?: string };
@@ -801,7 +74,7 @@ app.get(
   },
 );
 
-app.put('/grouping-types/:id', async (req: express.Request, res: express.Response) => {
+router.put('/grouping-types/:id', async (req: express.Request, res: express.Response) => {
   const { id } = req.params as { id?: string };
   const caller = (req as any).user as { userId: number };
   const gt = await prisma.groupingType.findUnique({ where: { id: Number(id) } });
@@ -835,7 +108,7 @@ app.put('/grouping-types/:id', async (req: express.Request, res: express.Respons
   res.json(updated);
 });
 
-app.delete('/grouping-types/:id', async (req: express.Request, res: express.Response) => {
+router.delete('/grouping-types/:id', async (req: express.Request, res: express.Response) => {
   const { id } = req.params as { id?: string };
   const caller = (req as any).user as { userId: number };
   const gt = await prisma.groupingType.findUnique({ where: { id: Number(id) } });
@@ -856,7 +129,7 @@ app.delete('/grouping-types/:id', async (req: express.Request, res: express.Resp
   res.json(updated);
 });
 
-app.post('/programs/:programId/groupings', async (req: express.Request, res: express.Response) => {
+router.post('/programs/:programId/groupings', async (req: express.Request, res: express.Response) => {
   const { programId } = req.params as { programId?: string };
   const caller = (req as any).user as { userId: number; email: string };
   if (!programId) {
@@ -894,7 +167,7 @@ app.post('/programs/:programId/groupings', async (req: express.Request, res: exp
   res.status(201).json(grouping);
 });
 
-app.get('/programs/:programId/groupings', async (req: express.Request, res: express.Response) => {
+router.get('/programs/:programId/groupings', async (req: express.Request, res: express.Response) => {
   const { programId } = req.params as { programId?: string };
   const caller = (req as any).user as { userId: number };
   if (!programId) {
@@ -913,7 +186,7 @@ app.get('/programs/:programId/groupings', async (req: express.Request, res: expr
   res.json(groupings);
 });
 
-app.put('/groupings/:id', async (req: express.Request, res: express.Response) => {
+router.put('/groupings/:id', async (req: express.Request, res: express.Response) => {
   const { id } = req.params as { id?: string };
   const caller = (req as any).user as { userId: number };
   const grouping = await prisma.grouping.findUnique({ where: { id: Number(id) } });
@@ -941,7 +214,7 @@ app.put('/groupings/:id', async (req: express.Request, res: express.Response) =>
   res.json(updated);
 });
 
-app.delete('/groupings/:id', async (req: express.Request, res: express.Response) => {
+router.delete('/groupings/:id', async (req: express.Request, res: express.Response) => {
   const { id } = req.params as { id?: string };
   const caller = (req as any).user as { userId: number };
   const grouping = await prisma.grouping.findUnique({ where: { id: Number(id) } });
@@ -962,7 +235,7 @@ app.delete('/groupings/:id', async (req: express.Request, res: express.Response)
   res.json(updated);
 });
 
-app.post('/program-years/:id/groupings/activate', async (req: express.Request, res: express.Response) => {
+router.post('/program-years/:id/groupings/activate', async (req: express.Request, res: express.Response) => {
   const { id } = req.params as { id?: string };
   const caller = (req as any).user as { userId: number };
   const py = await prisma.programYear.findUnique({ where: { id: Number(id) } });
@@ -991,7 +264,7 @@ app.post('/program-years/:id/groupings/activate', async (req: express.Request, r
   res.status(201).json(records);
 });
 
-app.get('/program-years/:id/groupings', async (req: express.Request, res: express.Response) => {
+router.get('/program-years/:id/groupings', async (req: express.Request, res: express.Response) => {
   const { id } = req.params as { id?: string };
   const caller = (req as any).user as { userId: number };
   const py = await prisma.programYear.findUnique({ where: { id: Number(id) } });
@@ -1011,7 +284,7 @@ app.get('/program-years/:id/groupings', async (req: express.Request, res: expres
   res.json(records);
 });
 
-app.post('/programs/:programId/parties', async (req: express.Request, res: express.Response) => {
+router.post('/programs/:programId/parties', async (req: express.Request, res: express.Response) => {
   const { programId } = req.params as { programId?: string };
   const caller = (req as any).user as { userId: number; email: string };
   if (!programId) {
@@ -1041,7 +314,7 @@ app.post('/programs/:programId/parties', async (req: express.Request, res: expre
   res.status(201).json(party);
 });
 
-app.get('/programs/:programId/parties', async (req: express.Request, res: express.Response) => {
+router.get('/programs/:programId/parties', async (req: express.Request, res: express.Response) => {
   const { programId } = req.params as { programId?: string };
   const caller = (req as any).user as { userId: number };
   if (!programId) {
@@ -1060,7 +333,7 @@ app.get('/programs/:programId/parties', async (req: express.Request, res: expres
   res.json(parties);
 });
 
-app.put('/parties/:id', async (req: express.Request, res: express.Response) => {
+router.put('/parties/:id', async (req: express.Request, res: express.Response) => {
   const { id } = req.params as { id?: string };
   const caller = (req as any).user as { userId: number };
   const party = await prisma.party.findUnique({ where: { id: Number(id) } });
@@ -1089,7 +362,7 @@ app.put('/parties/:id', async (req: express.Request, res: express.Response) => {
   res.json(updated);
 });
 
-app.delete('/parties/:id', async (req: express.Request, res: express.Response) => {
+router.delete('/parties/:id', async (req: express.Request, res: express.Response) => {
   const { id } = req.params as { id?: string };
   const caller = (req as any).user as { userId: number };
   const party = await prisma.party.findUnique({ where: { id: Number(id) } });
@@ -1110,7 +383,7 @@ app.delete('/parties/:id', async (req: express.Request, res: express.Response) =
   res.json(updated);
 });
 
-app.post('/program-years/:id/parties/activate', async (req: express.Request, res: express.Response) => {
+router.post('/program-years/:id/parties/activate', async (req: express.Request, res: express.Response) => {
   const { id } = req.params as { id?: string };
   const caller = (req as any).user as { userId: number };
   const py = await prisma.programYear.findUnique({ where: { id: Number(id) } });
@@ -1139,7 +412,7 @@ app.post('/program-years/:id/parties/activate', async (req: express.Request, res
   res.status(201).json(records);
 });
 
-app.get('/program-years/:id/parties', async (req: express.Request, res: express.Response) => {
+router.get('/program-years/:id/parties', async (req: express.Request, res: express.Response) => {
   const { id } = req.params as { id?: string };
   const caller = (req as any).user as { userId: number };
   const py = await prisma.programYear.findUnique({ where: { id: Number(id) } });
@@ -1159,7 +432,7 @@ app.get('/program-years/:id/parties', async (req: express.Request, res: express.
   res.json(records);
 });
 
-app.post('/programs/:programId/positions', async (req: express.Request, res: express.Response) => {
+router.post('/programs/:programId/positions', async (req: express.Request, res: express.Response) => {
   const { programId } = req.params as { programId?: string };
   const caller = (req as any).user as { userId: number; email: string };
   if (!programId) {
@@ -1187,7 +460,7 @@ app.post('/programs/:programId/positions', async (req: express.Request, res: exp
   res.status(201).json(position);
 });
 
-app.get('/programs/:programId/positions', async (req: express.Request, res: express.Response) => {
+router.get('/programs/:programId/positions', async (req: express.Request, res: express.Response) => {
   const { programId } = req.params as { programId?: string };
   const caller = (req as any).user as { userId: number };
   if (!programId) {
@@ -1206,7 +479,7 @@ app.get('/programs/:programId/positions', async (req: express.Request, res: expr
   res.json(positions);
 });
 
-app.put('/positions/:id', async (req: express.Request, res: express.Response) => {
+router.put('/positions/:id', async (req: express.Request, res: express.Response) => {
   const { id } = req.params as { id?: string };
   const caller = (req as any).user as { userId: number };
   const position = await prisma.position.findUnique({ where: { id: Number(id) } });
@@ -1233,7 +506,7 @@ app.put('/positions/:id', async (req: express.Request, res: express.Response) =>
   res.json(updated);
 });
 
-app.delete('/positions/:id', async (req: express.Request, res: express.Response) => {
+router.delete('/positions/:id', async (req: express.Request, res: express.Response) => {
   const { id } = req.params as { id?: string };
   const caller = (req as any).user as { userId: number };
   const position = await prisma.position.findUnique({ where: { id: Number(id) } });
@@ -1251,7 +524,7 @@ app.delete('/positions/:id', async (req: express.Request, res: express.Response)
   res.json(updated);
 });
 
-app.post('/program-years/:id/positions', async (req: express.Request, res: express.Response) => {
+router.post('/program-years/:id/positions', async (req: express.Request, res: express.Response) => {
   const { id } = req.params as { id?: string };
   const caller = (req as any).user as { userId: number };
   const py = await prisma.programYear.findUnique({ where: { id: Number(id) } });
@@ -1276,7 +549,7 @@ app.post('/program-years/:id/positions', async (req: express.Request, res: expre
   res.status(201).json(pypos);
 });
 
-app.get('/program-years/:id/positions', async (req: express.Request, res: express.Response) => {
+router.get('/program-years/:id/positions', async (req: express.Request, res: express.Response) => {
   const { id } = req.params as { id?: string };
   const caller = (req as any).user as { userId: number };
   const py = await prisma.programYear.findUnique({ where: { id: Number(id) } });
@@ -1296,7 +569,7 @@ app.get('/program-years/:id/positions', async (req: express.Request, res: expres
   res.json(records);
 });
 
-app.put('/program-year-positions/:id', async (req: express.Request, res: express.Response) => {
+router.put('/program-year-positions/:id', async (req: express.Request, res: express.Response) => {
   const { id } = req.params as { id?: string };
   const caller = (req as any).user as { userId: number };
   const record = await prisma.programYearPosition.findUnique({ where: { id: Number(id) } });
@@ -1320,7 +593,7 @@ app.put('/program-year-positions/:id', async (req: express.Request, res: express
   res.json(updated);
 });
 
-app.delete('/program-year-positions/:id', async (req: express.Request, res: express.Response) => {
+router.delete('/program-year-positions/:id', async (req: express.Request, res: express.Response) => {
   const { id } = req.params as { id?: string };
   const caller = (req as any).user as { userId: number };
   const record = await prisma.programYearPosition.findUnique({ where: { id: Number(id) } });
@@ -1343,7 +616,7 @@ app.delete('/program-year-positions/:id', async (req: express.Request, res: expr
   res.json(updated);
 });
 
-app.post('/program-years/:id/delegates', async (req: express.Request, res: express.Response) => {
+router.post('/program-years/:id/delegates', async (req: express.Request, res: express.Response) => {
   const { id } = req.params as { id?: string };
   const caller = (req as any).user as { userId: number };
   const py = await prisma.programYear.findUnique({ where: { id: Number(id) } });
@@ -1386,7 +659,7 @@ app.post('/program-years/:id/delegates', async (req: express.Request, res: expre
   res.status(201).json(delegate);
 });
 
-app.get('/program-years/:id/delegates', async (req: express.Request, res: express.Response) => {
+router.get('/program-years/:id/delegates', async (req: express.Request, res: express.Response) => {
   const { id } = req.params as { id?: string };
   const caller = (req as any).user as { userId: number };
   const py = await prisma.programYear.findUnique({ where: { id: Number(id) } });
@@ -1403,7 +676,7 @@ app.get('/program-years/:id/delegates', async (req: express.Request, res: expres
   res.json(delegates);
 });
 
-app.put('/delegates/:id', async (req: express.Request, res: express.Response) => {
+router.put('/delegates/:id', async (req: express.Request, res: express.Response) => {
   const { id } = req.params as { id?: string };
   const caller = (req as any).user as { userId: number };
   const delegate = await prisma.delegate.findUnique({ where: { id: Number(id) } });
@@ -1439,7 +712,7 @@ app.put('/delegates/:id', async (req: express.Request, res: express.Response) =>
   res.json(updated);
 });
 
-app.delete('/delegates/:id', async (req: express.Request, res: express.Response) => {
+router.delete('/delegates/:id', async (req: express.Request, res: express.Response) => {
   const { id } = req.params as { id?: string };
   const caller = (req as any).user as { userId: number };
   const delegate = await prisma.delegate.findUnique({ where: { id: Number(id) } });
@@ -1465,7 +738,7 @@ app.delete('/delegates/:id', async (req: express.Request, res: express.Response)
   res.json(updated);
 });
 
-app.post('/program-years/:id/staff', async (req: express.Request, res: express.Response) => {
+router.post('/program-years/:id/staff', async (req: express.Request, res: express.Response) => {
   const { id } = req.params as { id?: string };
   const caller = (req as any).user as { userId: number };
   const py = await prisma.programYear.findUnique({ where: { id: Number(id) } });
@@ -1508,7 +781,7 @@ app.post('/program-years/:id/staff', async (req: express.Request, res: express.R
   res.status(201).json(staff);
 });
 
-app.get('/program-years/:id/staff', async (req: express.Request, res: express.Response) => {
+router.get('/program-years/:id/staff', async (req: express.Request, res: express.Response) => {
   const { id } = req.params as { id?: string };
   const caller = (req as any).user as { userId: number };
   const py = await prisma.programYear.findUnique({ where: { id: Number(id) } });
@@ -1525,7 +798,7 @@ app.get('/program-years/:id/staff', async (req: express.Request, res: express.Re
   res.json(staffList);
 });
 
-app.put('/staff/:id', async (req: express.Request, res: express.Response) => {
+router.put('/staff/:id', async (req: express.Request, res: express.Response) => {
   const { id } = req.params as { id?: string };
   const caller = (req as any).user as { userId: number };
   const staff = await prisma.staff.findUnique({ where: { id: Number(id) } });
@@ -1561,7 +834,7 @@ app.put('/staff/:id', async (req: express.Request, res: express.Response) => {
   res.json(updated);
 });
 
-app.delete('/staff/:id', async (req: express.Request, res: express.Response) => {
+router.delete('/staff/:id', async (req: express.Request, res: express.Response) => {
   const { id } = req.params as { id?: string };
   const caller = (req as any).user as { userId: number };
   const staff = await prisma.staff.findUnique({ where: { id: Number(id) } });
@@ -1584,7 +857,7 @@ app.delete('/staff/:id', async (req: express.Request, res: express.Response) => 
   res.json(updated);
 });
 
-app.post('/program-years/:id/parents', async (req: express.Request, res: express.Response) => {
+router.post('/program-years/:id/parents', async (req: express.Request, res: express.Response) => {
   const { id } = req.params as { id?: string };
   const caller = (req as any).user as { userId: number };
   const py = await prisma.programYear.findUnique({ where: { id: Number(id) } });
@@ -1623,7 +896,7 @@ app.post('/program-years/:id/parents', async (req: express.Request, res: express
   res.status(201).json(parent);
 });
 
-app.get('/program-years/:id/parents', async (req: express.Request, res: express.Response) => {
+router.get('/program-years/:id/parents', async (req: express.Request, res: express.Response) => {
   const { id } = req.params as { id?: string };
   const caller = (req as any).user as { userId: number };
   const py = await prisma.programYear.findUnique({ where: { id: Number(id) } });
@@ -1640,7 +913,7 @@ app.get('/program-years/:id/parents', async (req: express.Request, res: express.
   res.json(parents);
 });
 
-app.put('/parents/:id', async (req: express.Request, res: express.Response) => {
+router.put('/parents/:id', async (req: express.Request, res: express.Response) => {
   const { id } = req.params as { id?: string };
   const caller = (req as any).user as { userId: number };
   const parent = await prisma.parent.findUnique({ where: { id: Number(id) } });
@@ -1674,7 +947,7 @@ app.put('/parents/:id', async (req: express.Request, res: express.Response) => {
   res.json(updated);
 });
 
-app.delete('/parents/:id', async (req: express.Request, res: express.Response) => {
+router.delete('/parents/:id', async (req: express.Request, res: express.Response) => {
   const { id } = req.params as { id?: string };
   const caller = (req as any).user as { userId: number };
   const parent = await prisma.parent.findUnique({ where: { id: Number(id) } });
@@ -1697,7 +970,7 @@ app.delete('/parents/:id', async (req: express.Request, res: express.Response) =
   res.json(updated);
 });
 
-app.post('/delegate-parent-links', async (req: express.Request, res: express.Response) => {
+router.post('/delegate-parent-links', async (req: express.Request, res: express.Response) => {
   const caller = (req as any).user as { userId: number };
   const { delegateId, parentId, programYearId } = req.body as {
     delegateId?: number;
@@ -1725,7 +998,7 @@ app.post('/delegate-parent-links', async (req: express.Request, res: express.Res
   res.status(201).json(link);
 });
 
-app.put('/delegate-parent-links/:id', async (req: express.Request, res: express.Response) => {
+router.put('/delegate-parent-links/:id', async (req: express.Request, res: express.Response) => {
   const { id } = req.params as { id?: string };
   const caller = (req as any).user as { userId: number };
   const link = await prisma.delegateParentLink.findUnique({ where: { id: Number(id) } });
@@ -1749,7 +1022,7 @@ app.put('/delegate-parent-links/:id', async (req: express.Request, res: express.
   res.json(updated);
 });
 
-app.post('/program-years/:id/elections', async (req: express.Request, res: express.Response) => {
+router.post('/program-years/:id/elections', async (req: express.Request, res: express.Response) => {
   const { id } = req.params as { id?: string };
   const caller = (req as any).user as { userId: number };
   const py = await prisma.programYear.findUnique({ where: { id: Number(id) } });
@@ -1788,7 +1061,7 @@ app.post('/program-years/:id/elections', async (req: express.Request, res: expre
   res.status(201).json(election);
 });
 
-app.get('/program-years/:id/elections', async (req: express.Request, res: express.Response) => {
+router.get('/program-years/:id/elections', async (req: express.Request, res: express.Response) => {
   const { id } = req.params as { id?: string };
   const caller = (req as any).user as { userId: number };
   const py = await prisma.programYear.findUnique({ where: { id: Number(id) } });
@@ -1805,7 +1078,7 @@ app.get('/program-years/:id/elections', async (req: express.Request, res: expres
   res.json(elections);
 });
 
-app.put('/elections/:id', async (req: express.Request, res: express.Response) => {
+router.put('/elections/:id', async (req: express.Request, res: express.Response) => {
   const { id } = req.params as { id?: string };
   const caller = (req as any).user as { userId: number };
   const election = await prisma.election.findUnique({ where: { id: Number(id) } });
@@ -1840,7 +1113,7 @@ app.put('/elections/:id', async (req: express.Request, res: express.Response) =>
   res.json(updated);
 });
 
-app.delete('/elections/:id', async (req: express.Request, res: express.Response) => {
+router.delete('/elections/:id', async (req: express.Request, res: express.Response) => {
   const { id } = req.params as { id?: string };
   const caller = (req as any).user as { userId: number };
   const election = await prisma.election.findUnique({ where: { id: Number(id) } });
@@ -1863,7 +1136,7 @@ app.delete('/elections/:id', async (req: express.Request, res: express.Response)
   res.json(updated);
 });
 
-app.post('/elections/:id/vote', async (req: express.Request, res: express.Response) => {
+router.post('/elections/:id/vote', async (req: express.Request, res: express.Response) => {
   const { id } = req.params as { id?: string };
   const caller = (req as any).user as { userId: number };
   const election = await prisma.election.findUnique({ where: { id: Number(id) } });
@@ -1897,7 +1170,7 @@ app.post('/elections/:id/vote', async (req: express.Request, res: express.Respon
   res.status(201).json(vote);
 });
 
-app.get('/elections/:id/results', async (req: express.Request, res: express.Response) => {
+router.get('/elections/:id/results', async (req: express.Request, res: express.Response) => {
   const { id } = req.params as { id?: string };
   const caller = (req as any).user as { userId: number };
   const election = await prisma.election.findUnique({ where: { id: Number(id) } });
@@ -1923,12 +1196,4 @@ app.get('/elections/:id/results', async (req: express.Request, res: express.Resp
   res.json({ results: votes });
 });
 
-if (process.env.NODE_ENV !== 'test') {
-  ensureDatabase();
-  app.listen(port, () => {
-    logger.info('system', `Server listening on port ${port}`);
-  });
-}
-
-export { loginAttempts, ensureDatabase };
-export default app;
+export default router;

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -1,0 +1,78 @@
+import express from 'express';
+import { randomBytes, scrypt as _scrypt } from 'crypto';
+import { promisify } from 'util';
+import prisma from '../prisma';
+import { sign } from '../jwt';
+import * as logger from '../logger';
+
+const scrypt = promisify(_scrypt);
+const router = express.Router();
+
+export const loginAttempts = new Map<string, { count: number; lastAttempt: number }>();
+const MAX_LOGIN_ATTEMPTS = 5;
+const LOGIN_WINDOW_MS = 15 * 60 * 1000; // 15 minutes
+const jwtSecret = process.env.JWT_SECRET || 'development-secret';
+
+router.post('/register', async (req: express.Request, res: express.Response) => {
+  const { email, password } = req.body as { email?: string; password?: string };
+  if (!email || !password) {
+    res.status(400).json({ error: 'Email and password required' });
+    return;
+  }
+
+  const existing = await prisma.user.findUnique({ where: { email } });
+  if (existing) {
+    res.status(400).json({ error: 'User already exists' });
+    return;
+  }
+
+  const salt = randomBytes(16).toString('hex');
+  const buf = (await scrypt(password, salt, 64)) as Buffer;
+  const hashed = `${salt}:${buf.toString('hex')}`;
+
+  await prisma.user.create({ data: { email, password: hashed } });
+  logger.info('system', `User registered: ${email}`);
+  res.status(201).json({ message: 'User created' });
+});
+
+router.post('/login', async (req: express.Request, res: express.Response) => {
+  const { email, password } = req.body as { email?: string; password?: string };
+  if (!email || !password) {
+    res.status(400).json({ error: 'Email and password required' });
+    return;
+  }
+
+  const now = Date.now();
+  const ip = req.ip || '';
+  const attempt = loginAttempts.get(ip);
+  if (attempt && now - attempt.lastAttempt < LOGIN_WINDOW_MS && attempt.count >= MAX_LOGIN_ATTEMPTS) {
+    logger.warn('system', `Too many login attempts from ${ip}`);
+    res.status(429).json({ error: 'Too many login attempts' });
+    return;
+  }
+
+  const user = await prisma.user.findUnique({ where: { email } });
+  if (!user) {
+    const count = attempt && now - attempt.lastAttempt < LOGIN_WINDOW_MS ? attempt.count + 1 : 1;
+    loginAttempts.set(ip, { count, lastAttempt: now });
+    res.status(401).json({ error: 'Invalid credentials' });
+    return;
+  }
+
+  const [salt, storedHash] = user.password.split(':');
+  const buf = (await scrypt(password, salt, 64)) as Buffer;
+  if (buf.toString('hex') !== storedHash) {
+    const count = attempt && now - attempt.lastAttempt < LOGIN_WINDOW_MS ? attempt.count + 1 : 1;
+    loginAttempts.set(ip, { count, lastAttempt: now });
+    res.status(401).json({ error: 'Invalid credentials' });
+    return;
+  }
+
+  loginAttempts.delete(ip);
+
+  const token = sign({ userId: user.id, email: user.email }, jwtSecret);
+  logger.info('system', `User logged in: ${email}`);
+  res.json({ token });
+});
+
+export default router;

--- a/src/routes/programYears.ts
+++ b/src/routes/programYears.ts
@@ -1,0 +1,138 @@
+import express from "express";
+import prisma from "../prisma";
+import * as logger from "../logger";
+import { isProgramAdmin, isProgramMember } from "../utils/auth";
+const router = express.Router();
+
+router.post(
+  '/programs/:programId/years',
+  async (req: express.Request, res: express.Response) => {
+    const { programId } = req.params as { programId?: string };
+    const caller = (req as any).user as { userId: number; email: string };
+    if (!programId) {
+      res.status(400).json({ error: 'programId required' });
+      return;
+    }
+    const isAdmin = await isProgramAdmin(caller.userId, programId);
+    if (!isAdmin) {
+      res.status(403).json({ error: 'Forbidden' });
+      return;
+    }
+    const { year, startDate, endDate, status, notes } = req.body as {
+      year?: number;
+      startDate?: string;
+      endDate?: string;
+      status?: string;
+      notes?: string;
+    };
+    if (!year) {
+      res.status(400).json({ error: 'year required' });
+      return;
+    }
+    const py = await prisma.programYear.create({
+      data: {
+        programId,
+        year,
+        startDate: startDate ? new Date(startDate) : undefined,
+        endDate: endDate ? new Date(endDate) : undefined,
+        status: status || 'active',
+        notes,
+      },
+    });
+    logger.info(programId, `Program year ${year} created`);
+    res.status(201).json(py);
+  },
+);
+
+router.get(
+  '/programs/:programId/years',
+  async (req: express.Request, res: express.Response) => {
+    const { programId } = req.params as { programId?: string };
+    const caller = (req as any).user as { userId: number };
+    if (!programId) {
+      res.status(400).json({ error: 'programId required' });
+      return;
+    }
+    const isMember = await isProgramMember(caller.userId, programId);
+    if (!isMember) {
+      res.status(403).json({ error: 'Forbidden' });
+      return;
+    }
+    const years = await prisma.programYear.findMany({
+      where: { programId },
+      orderBy: { year: 'desc' },
+    });
+    res.json(years);
+  },
+);
+
+router.get('/program-years/:id', async (req: express.Request, res: express.Response) => {
+  const { id } = req.params as { id?: string };
+  const caller = (req as any).user as { userId: number };
+  const py = await prisma.programYear.findUnique({ where: { id: Number(id) } });
+  if (!py) {
+    res.status(404).json({ error: 'Not found' });
+    return;
+  }
+  const isMember = await isProgramMember(caller.userId, py.programId);
+  if (!isMember) {
+    res.status(403).json({ error: 'Forbidden' });
+    return;
+  }
+  res.json(py);
+});
+
+router.put('/program-years/:id', async (req: express.Request, res: express.Response) => {
+  const { id } = req.params as { id?: string };
+  const caller = (req as any).user as { userId: number };
+  const py = await prisma.programYear.findUnique({ where: { id: Number(id) } });
+  if (!py) {
+    res.status(404).json({ error: 'Not found' });
+    return;
+  }
+  const isAdmin = await isProgramAdmin(caller.userId, py.programId);
+  if (!isAdmin) {
+    res.status(403).json({ error: 'Forbidden' });
+    return;
+  }
+  const { startDate, endDate, status, notes } = req.body as {
+    startDate?: string;
+    endDate?: string;
+    status?: string;
+    notes?: string;
+  };
+  const updated = await prisma.programYear.update({
+    where: { id: Number(id) },
+    data: {
+      startDate: startDate ? new Date(startDate) : undefined,
+      endDate: endDate ? new Date(endDate) : undefined,
+      status,
+      notes,
+    },
+  });
+  logger.info(py.programId, `Program year ${py.year} updated`);
+  res.json(updated);
+});
+
+router.delete('/program-years/:id', async (req: express.Request, res: express.Response) => {
+  const { id } = req.params as { id?: string };
+  const caller = (req as any).user as { userId: number };
+  const py = await prisma.programYear.findUnique({ where: { id: Number(id) } });
+  if (!py) {
+    res.status(404).json({ error: 'Not found' });
+    return;
+  }
+  const isAdmin = await isProgramAdmin(caller.userId, py.programId);
+  if (!isAdmin) {
+    res.status(403).json({ error: 'Forbidden' });
+    return;
+  }
+  const updated = await prisma.programYear.update({
+    where: { id: Number(id) },
+    data: { status: 'archived' },
+  });
+  logger.info(py.programId, `Program year ${py.year} archived`);
+  res.json(updated);
+});
+
+export default router;

--- a/src/routes/programs.ts
+++ b/src/routes/programs.ts
@@ -1,0 +1,360 @@
+import express from 'express';
+import prisma from '../prisma';
+import * as logger from '../logger';
+import { isProgramAdmin, isProgramMember, getUserPrograms } from "../utils/auth";
+const router = express.Router();
+
+router.post('/programs', async (req: express.Request, res: express.Response) => {
+  const user = (req as any).user as { userId: number; email: string };
+  const { name, year, config } = req.body as {
+    name?: string;
+    year?: number;
+    config?: any;
+  };
+  if (!name || !year) {
+    res.status(400).json({ error: 'name and year required' });
+    return;
+  }
+  const program = await prisma.program.create({
+    data: {
+      name,
+      year,
+      config,
+      createdBy: { connect: { id: user.userId } },
+    },
+  });
+  await prisma.programAssignment.create({
+    data: { userId: user.userId, programId: program.id, role: 'admin' },
+  });
+  logger.info(program.id, `Program created by ${user.email}`);
+  res.status(201).json({
+    id: program.id,
+    name: program.name,
+    year: program.year,
+    createdBy: user.userId,
+    roleAssigned: 'admin',
+  });
+});
+
+router.get('/programs', async (_req: express.Request, res: express.Response) => {
+  const programs = await prisma.program.findMany();
+  res.json(programs);
+});
+
+
+router.post(
+  '/programs/:programId/users',
+  async (req: express.Request, res: express.Response) => {
+    const { programId } = req.params as { programId?: string };
+    const caller = (req as any).user as { userId: number; email: string };
+    if (!programId) {
+      res.status(400).json({ error: 'programId required' });
+      return;
+    }
+    const isAdmin = await isProgramAdmin(caller.userId, programId);
+    if (!isAdmin) {
+      res.status(403).json({ error: 'Forbidden' });
+      return;
+    }
+    const { userId, role } = req.body as { userId?: number; role?: string };
+    if (!userId || !role) {
+      res.status(400).json({ error: 'userId and role required' });
+      return;
+    }
+    await prisma.programAssignment.create({
+      data: { userId, programId, role },
+    });
+    logger.info(programId, `User ${userId} assigned role ${role}`);
+    res.status(201).json({
+      programId,
+      userId,
+      role,
+      status: 'assigned',
+    });
+  },
+);
+
+router.get(
+  '/programs/:programId/users',
+  async (req: express.Request, res: express.Response) => {
+    const { programId } = req.params as { programId?: string };
+    const caller = (req as any).user as { userId: number; email: string };
+    if (!programId) {
+      res.status(400).json({ error: 'programId required' });
+      return;
+    }
+    const isAdmin = await isProgramAdmin(caller.userId, programId);
+    if (!isAdmin) {
+      res.status(403).json({ error: 'Forbidden' });
+      return;
+    }
+    const assignments = await prisma.programAssignment.findMany({
+      where: { programId },
+      select: { userId: true, role: true },
+    });
+    logger.info(programId, `Listed users for program`);
+    res.json(assignments);
+  },
+);
+
+router.post(
+  '/programs/:programId/years',
+  async (req: express.Request, res: express.Response) => {
+    const { programId } = req.params as { programId?: string };
+    const caller = (req as any).user as { userId: number; email: string };
+    if (!programId) {
+      res.status(400).json({ error: 'programId required' });
+      return;
+    }
+    const isAdmin = await isProgramAdmin(caller.userId, programId);
+    if (!isAdmin) {
+      res.status(403).json({ error: 'Forbidden' });
+      return;
+    }
+    const { year, startDate, endDate, status, notes } = req.body as {
+      year?: number;
+      startDate?: string;
+      endDate?: string;
+      status?: string;
+      notes?: string;
+    };
+    if (!year) {
+      res.status(400).json({ error: 'year required' });
+      return;
+    }
+    const py = await prisma.programYear.create({
+      data: {
+        programId,
+        year,
+        startDate: startDate ? new Date(startDate) : undefined,
+        endDate: endDate ? new Date(endDate) : undefined,
+        status: status || 'active',
+        notes,
+      },
+    });
+    logger.info(programId, `Program year ${year} created`);
+    res.status(201).json(py);
+  },
+);
+
+router.get(
+  '/programs/:programId/years',
+  async (req: express.Request, res: express.Response) => {
+    const { programId } = req.params as { programId?: string };
+    const caller = (req as any).user as { userId: number };
+    if (!programId) {
+      res.status(400).json({ error: 'programId required' });
+      return;
+    }
+    const isMember = await isProgramMember(caller.userId, programId);
+    if (!isMember) {
+      res.status(403).json({ error: 'Forbidden' });
+      return;
+    }
+    const years = await prisma.programYear.findMany({
+      where: { programId },
+      orderBy: { year: 'desc' },
+    });
+    res.json(years);
+  },
+);
+
+router.get('/program-years/:id', async (req: express.Request, res: express.Response) => {
+  const { id } = req.params as { id?: string };
+  const caller = (req as any).user as { userId: number };
+  const py = await prisma.programYear.findUnique({ where: { id: Number(id) } });
+  if (!py) {
+    res.status(404).json({ error: 'Not found' });
+    return;
+  }
+  const isMember = await isProgramMember(caller.userId, py.programId);
+  if (!isMember) {
+    res.status(403).json({ error: 'Forbidden' });
+    return;
+  }
+  res.json(py);
+});
+
+router.put('/program-years/:id', async (req: express.Request, res: express.Response) => {
+  const { id } = req.params as { id?: string };
+  const caller = (req as any).user as { userId: number };
+  const py = await prisma.programYear.findUnique({ where: { id: Number(id) } });
+  if (!py) {
+    res.status(404).json({ error: 'Not found' });
+    return;
+  }
+  const isAdmin = await isProgramAdmin(caller.userId, py.programId);
+  if (!isAdmin) {
+    res.status(403).json({ error: 'Forbidden' });
+    return;
+  }
+  const { startDate, endDate, status, notes } = req.body as {
+    startDate?: string;
+    endDate?: string;
+    status?: string;
+    notes?: string;
+  };
+  const updated = await prisma.programYear.update({
+    where: { id: Number(id) },
+    data: {
+      startDate: startDate ? new Date(startDate) : undefined,
+      endDate: endDate ? new Date(endDate) : undefined,
+      status,
+      notes,
+    },
+  });
+  logger.info(py.programId, `Program year ${py.year} updated`);
+  res.json(updated);
+});
+
+router.delete('/program-years/:id', async (req: express.Request, res: express.Response) => {
+  const { id } = req.params as { id?: string };
+  const caller = (req as any).user as { userId: number };
+  const py = await prisma.programYear.findUnique({ where: { id: Number(id) } });
+  if (!py) {
+    res.status(404).json({ error: 'Not found' });
+    return;
+  }
+  const isAdmin = await isProgramAdmin(caller.userId, py.programId);
+  if (!isAdmin) {
+    res.status(403).json({ error: 'Forbidden' });
+    return;
+  }
+  const updated = await prisma.programYear.update({
+    where: { id: Number(id) },
+    data: { status: 'archived' },
+  });
+  logger.info(py.programId, `Program year ${py.year} archived`);
+  res.json(updated);
+});
+
+router.get('/user-programs/:username', getUserPrograms);
+
+router.get('/programs/:id', async (req: express.Request, res: express.Response) => {
+  const { id } = req.params as { id?: string };
+  const caller = (req as any).user as { userId: number };
+  const program = await prisma.program.findUnique({ where: { id } });
+  if (!program) {
+    res.status(404).json({ error: 'Not found' });
+    return;
+  }
+  const member = await isProgramMember(caller.userId, id!);
+  if (!member) {
+    res.status(403).json({ error: 'Forbidden' });
+    return;
+  }
+  res.json(program);
+});
+
+router.get('/programs/:id/branding', async (req: express.Request, res: express.Response) => {
+  const { id } = req.params as { id?: string };
+  const caller = (req as any).user as { userId: number };
+  const program = await prisma.program.findUnique({ where: { id } });
+  if (!program) {
+    res.status(404).json({ error: 'Not found' });
+    return;
+  }
+  const member = await isProgramMember(caller.userId, id!);
+  if (!member) {
+    res.status(403).json({ error: 'Forbidden' });
+    return;
+  }
+  const branding = {
+    brandingLogoUrl: program.brandingLogoUrl,
+    brandingPrimaryColor: program.brandingPrimaryColor,
+    brandingSecondaryColor: program.brandingSecondaryColor,
+    welcomeMessage: program.welcomeMessage,
+    contactEmail: program.contactEmail,
+    contactPhone: program.contactPhone,
+    socialLinks: program.socialLinks,
+  };
+  res.json(branding);
+});
+
+router.put('/programs/:id/branding', async (req: express.Request, res: express.Response) => {
+  const { id } = req.params as { id?: string };
+  const caller = (req as any).user as { userId: number; email: string };
+  const program = await prisma.program.findUnique({ where: { id } });
+  if (!program) {
+    res.status(404).json({ error: 'Not found' });
+    return;
+  }
+  const isAdmin = await isProgramAdmin(caller.userId, id!);
+  if (!isAdmin) {
+    res.status(403).json({ error: 'Forbidden' });
+    return;
+  }
+  const {
+    brandingLogoUrl,
+    brandingPrimaryColor,
+    brandingSecondaryColor,
+    welcomeMessage,
+    contactEmail,
+    contactPhone,
+    socialLinks,
+  } = req.body as any;
+  const updated = await prisma.program.update({
+    where: { id },
+    data: {
+      brandingLogoUrl,
+      brandingPrimaryColor,
+      brandingSecondaryColor,
+      welcomeMessage,
+      contactEmail,
+      contactPhone,
+      socialLinks,
+    },
+  });
+  logger.info(id!, `Branding updated by ${caller.email}`);
+  res.json(updated);
+});
+
+router.put('/programs/:id', async (req: express.Request, res: express.Response) => {
+  const { id } = req.params as { id?: string };
+  const caller = (req as any).user as { userId: number; email: string };
+  const program = await prisma.program.findUnique({ where: { id } });
+  if (!program) {
+    res.status(404).json({ error: 'Not found' });
+    return;
+  }
+  const isAdmin = await isProgramAdmin(caller.userId, id!);
+  if (!isAdmin) {
+    res.status(403).json({ error: 'Forbidden' });
+    return;
+  }
+  const { name, year, config, status } = req.body as {
+    name?: string;
+    year?: number;
+    config?: any;
+    status?: string;
+  };
+  const updated = await prisma.program.update({
+    where: { id },
+    data: { name, year, config, status },
+  });
+  logger.info(id!, `Program updated by ${caller.email}`);
+  res.json(updated);
+});
+
+router.delete('/programs/:id', async (req: express.Request, res: express.Response) => {
+  const { id } = req.params as { id?: string };
+  const caller = (req as any).user as { userId: number; email: string };
+  const program = await prisma.program.findUnique({ where: { id } });
+  if (!program) {
+    res.status(404).json({ error: 'Not found' });
+    return;
+  }
+  const isAdmin = await isProgramAdmin(caller.userId, id!);
+  if (!isAdmin) {
+    res.status(403).json({ error: 'Forbidden' });
+    return;
+  }
+  const updated = await prisma.program.update({
+    where: { id },
+    data: { status: 'retired' },
+  });
+  logger.info(id!, `Program retired by ${caller.email}`);
+  res.json(updated);
+});
+
+export default router;

--- a/src/routes/system.ts
+++ b/src/routes/system.ts
@@ -1,0 +1,205 @@
+import express from 'express';
+import { readFileSync } from 'fs';
+import path from 'path';
+import swaggerUi from 'swagger-ui-express';
+import yaml from 'yaml';
+import prisma from '../prisma';
+import * as logger from '../logger';
+
+const router = express.Router();
+
+const openApiPath = path.join(__dirname, '..', 'openapi.yaml');
+const swaggerDoc = yaml.parse(readFileSync(openApiPath, 'utf8'));
+
+const port = process.env.PORT || 3000;
+if (process.env.NODE_ENV !== 'production') {
+  swaggerDoc.servers = [{ url: `http://localhost:${port}` }];
+}
+
+router.get('/docs/swagger.json', (_req, res) => {
+  res.json(swaggerDoc);
+});
+
+router.get('/docs/swagger-ui-custom.js', (_req, res) => {
+  res.sendFile(path.join(__dirname, '..', 'swagger-ui-custom.js'));
+});
+
+router.use('/docs', swaggerUi.serve, swaggerUi.setup(swaggerDoc, { customJs: 'swagger-ui-custom.js' }));
+
+router.get('/health', async (_req, res) => {
+  logger.info('system', 'Serving /health');
+  let dbStatus = 'ok';
+  try {
+    await prisma.$queryRaw`SELECT 1`;
+  } catch (err) {
+    logger.error('system', 'Database check failed', err);
+    dbStatus = 'error';
+  }
+  res.json({ status: 'ok', database: dbStatus });
+});
+
+router.post('/logs', (req: express.Request, res: express.Response) => {
+  const { programId, level, message, error, source } = req.body as {
+    programId?: string;
+    level?: string;
+    message?: string;
+    error?: string;
+    source?: string;
+  };
+  if (!programId || !level || !message) {
+    res.status(400).json({ error: 'programId, level, and message required' });
+    return;
+  }
+  const lvl = level as string;
+  if (!['debug', 'info', 'warn', 'error'].includes(lvl)) {
+    res.status(400).json({ error: 'Invalid level' });
+    return;
+  }
+  const src = source || 'client';
+  switch (lvl) {
+    case 'debug':
+      logger.debug(programId, message, src);
+      break;
+    case 'info':
+      logger.info(programId, message, src);
+      break;
+    case 'warn':
+      logger.warn(programId, message, src);
+      break;
+    case 'error':
+      logger.error(programId, message, error, src);
+      break;
+  }
+  res.status(204).send();
+});
+
+router.get('/logs', async (req: express.Request, res: express.Response) => {
+  const {
+    programId,
+    level,
+    source,
+    dateFrom,
+    dateTo,
+    search,
+    page = '1',
+    pageSize = '50',
+  } = req.query as {
+    programId?: string;
+    level?: string;
+    source?: string;
+    dateFrom?: string;
+    dateTo?: string;
+    search?: string;
+    page?: string;
+    pageSize?: string;
+  };
+
+  if (level && !['debug', 'info', 'warn', 'error'].includes(level)) {
+    res.status(400).json({ error: 'Invalid level' });
+    return;
+  }
+
+  let p = parseInt(page, 10);
+  if (isNaN(p) || p < 1) p = 1;
+  let size = parseInt(pageSize, 10);
+  if (isNaN(size) || size < 1) size = 50;
+  if (size > 100) size = 100;
+
+  const where: any = {};
+  if (programId) where.programId = programId;
+  if (level) where.level = level;
+  if (source) where.source = source;
+  if (dateFrom || dateTo) {
+    where.timestamp = {} as any;
+    if (dateFrom) (where.timestamp as any).gte = new Date(dateFrom);
+    if (dateTo) (where.timestamp as any).lte = new Date(dateTo);
+  }
+
+  if (search) {
+    const contains = { contains: search, mode: 'insensitive' as const };
+    where.OR = [{ message: contains }, { error: contains }, { source: contains }];
+  }
+
+  const total = await prisma.log.count({ where });
+  const logs = await prisma.log.findMany({
+    where,
+    orderBy: { timestamp: 'desc' },
+    skip: (p - 1) * size,
+    take: size,
+  });
+
+  res.json({ logs, page: p, pageSize: size, total });
+});
+
+router.post('/audit-logs', async (req: express.Request, res: express.Response) => {
+  const { tableName, recordId, userId, action, changes } = req.body as {
+    tableName?: string;
+    recordId?: string | number;
+    userId?: number;
+    action?: string;
+    changes?: any;
+  };
+  if (!tableName || recordId === undefined || !userId || !action) {
+    res.status(400).json({ error: 'tableName, recordId, userId and action required' });
+    return;
+  }
+  const log = await prisma.auditLog.create({
+    data: {
+      tableName,
+      recordId: String(recordId),
+      userId,
+      action,
+      changes,
+    },
+  });
+  res.status(201).json(log);
+});
+
+router.get('/audit-logs', async (req: express.Request, res: express.Response) => {
+  const {
+    tableName,
+    recordId,
+    userId,
+    dateFrom,
+    dateTo,
+    page = '1',
+    pageSize = '50',
+  } = req.query as {
+    tableName?: string;
+    recordId?: string;
+    userId?: string;
+    dateFrom?: string;
+    dateTo?: string;
+    page?: string;
+    pageSize?: string;
+  };
+
+  let p = parseInt(page, 10);
+  if (isNaN(p) || p < 1) p = 1;
+  let size = parseInt(pageSize, 10);
+  if (isNaN(size) || size < 1) size = 50;
+  if (size > 100) size = 100;
+
+  const where: any = {};
+  if (tableName) where.tableName = tableName;
+  if (recordId) where.recordId = recordId;
+  if (userId) where.userId = Number(userId);
+  if (dateFrom || dateTo) {
+    where.timestamp = {} as any;
+    if (dateFrom) (where.timestamp as any).gte = new Date(dateFrom);
+    if (dateTo) (where.timestamp as any).lte = new Date(dateTo);
+  }
+
+  const total = await prisma.auditLog.count({ where });
+  const logs = await prisma.auditLog.findMany({
+    where,
+    orderBy: { timestamp: 'desc' },
+    skip: (p - 1) * size,
+    take: size,
+  });
+
+  res.json({ auditLogs: logs, page: p, pageSize: size, total });
+});
+
+export { swaggerDoc };
+export default router;

--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -1,0 +1,7 @@
+import express from 'express';
+import { getUserPrograms } from '../utils/auth';
+const router = express.Router();
+
+router.get('/user-programs/:username', getUserPrograms);
+
+export default router;

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,0 +1,48 @@
+import prisma from '../prisma';
+import * as logger from '../logger';
+import express from 'express';
+
+export async function isProgramAdmin(userId: number, programId: string) {
+  const assignment = await prisma.programAssignment.findFirst({
+    where: { userId, programId },
+  });
+  return assignment?.role === 'admin';
+}
+
+export async function isProgramMember(userId: number, programId: string) {
+  const assignment = await prisma.programAssignment.findFirst({
+    where: { userId, programId },
+  });
+  return Boolean(assignment);
+}
+
+export async function getUserPrograms(
+  req: express.Request,
+  res: express.Response,
+) {
+  const { username } = req.params as { username?: string };
+  if (!username) {
+    res.status(400).json({ error: 'Username required' });
+    return;
+  }
+
+  const user = await prisma.user.findUnique({ where: { email: username } });
+  if (!user) {
+    res.status(404).json({ error: 'User not found' });
+    return;
+  }
+
+  const assignments = await prisma.programAssignment.findMany({
+    where: { userId: user.id },
+    include: { program: true },
+  });
+  const programs = assignments.map((a: any) => ({
+    programId: a.program.id,
+    programName: a.program.name,
+    role: a.role,
+  }));
+  programs.forEach((p: any) => {
+    logger.info(p.programId, `Program lookup for ${user.email}`);
+  });
+  res.json({ username: user.email, programs });
+}


### PR DESCRIPTION
## Summary
- break out programs and program year handlers from api routes
- add separate users router for `/user-programs/:username`
- wire new routers into app setup
- update build output

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_686bacedc188832d8c69dc1203dce1d7