### PR TITLE
Fix logs test path

### DIFF
--- a/__tests__/logs.test.ts
+++ b/__tests__/logs.test.ts
@@ -1,6 +1,10 @@
 import request from 'supertest';
 import { rmSync, existsSync } from 'fs';
 import path from 'path';
+import os from 'os';
+
+// Use a temporary logs directory so other tests don't interfere
+process.env.LOGS_DIR = path.join(os.tmpdir(), 'logs-test');
 jest.mock('../src/prisma');
 import app from '../src/index';
 import { sign } from '../src/jwt';
@@ -8,9 +12,15 @@ import prisma from '../src/prisma';
 
 describe('POST /logs', () => {
   const token = sign({ userId: 1, email: 'admin@example.com' }, 'development-secret');
-  const logsDir = path.join(__dirname, '..', 'logs');
+  const logsDir = process.env.LOGS_DIR as string;
 
   beforeAll(() => {
+    if (existsSync(logsDir)) {
+      rmSync(logsDir, { recursive: true, force: true });
+    }
+  });
+
+  afterAll(() => {
     if (existsSync(logsDir)) {
       rmSync(logsDir, { recursive: true, force: true });
     }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -13,8 +13,10 @@ interface LogEntry {
   error?: string;
 }
 
+const baseLogsDir = process.env.LOGS_DIR || path.join(__dirname, '..', 'logs');
+
 function writeLog(entry: LogEntry) {
-  const logsDir = path.join(__dirname, '..', 'logs');
+  const logsDir = baseLogsDir;
   if (!existsSync(logsDir)) {
     mkdirSync(logsDir, { recursive: true });
   }


### PR DESCRIPTION
## Summary
- allow overriding logs directory via `LOGS_DIR`
- isolate logs.test by writing to a temp dir

## Testing
- `npm test --silent`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_686bbffb838c832d97d4bc700cc780cd