### PR TITLE
Add comprehensive error tests for higher coverage

### DIFF
--- a/__tests__/authUtils.test.ts
+++ b/__tests__/authUtils.test.ts
@@ -1,0 +1,35 @@
+jest.mock('../src/prisma');
+import prisma from '../src/prisma';
+import { isProgramAdmin, isProgramMember } from '../src/utils/auth';
+
+const mockedPrisma = prisma as any;
+
+describe('auth utils', () => {
+  beforeEach(() => {
+    mockedPrisma.programAssignment.findFirst.mockReset();
+  });
+
+  it('isProgramAdmin true when role admin', async () => {
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'admin' });
+    const result = await isProgramAdmin(1, 'abc');
+    expect(result).toBe(true);
+  });
+
+  it('isProgramAdmin false when other role', async () => {
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'delegate' });
+    const result = await isProgramAdmin(1, 'abc');
+    expect(result).toBe(false);
+  });
+
+  it('isProgramMember true when assignment exists', async () => {
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'delegate' });
+    const result = await isProgramMember(1, 'abc');
+    expect(result).toBe(true);
+  });
+
+  it('isProgramMember false when none', async () => {
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce(null);
+    const result = await isProgramMember(1, 'abc');
+    expect(result).toBe(false);
+  });
+});

--- a/__tests__/delegates.error.test.ts
+++ b/__tests__/delegates.error.test.ts
@@ -1,0 +1,74 @@
+import request from 'supertest';
+jest.mock('../src/prisma');
+import prisma from '../src/prisma';
+import app from '../src/index';
+import { sign } from '../src/jwt';
+
+const mockedPrisma = prisma as any;
+const token = sign({ userId: 1, email: 'admin@example.com' }, 'development-secret');
+
+beforeEach(() => {
+  mockedPrisma.programAssignment.findFirst.mockReset();
+  mockedPrisma.delegate.findUnique.mockReset();
+  mockedPrisma.delegate.update.mockReset();
+  mockedPrisma.delegate.create.mockReset();
+});
+
+describe('Delegate error cases', () => {
+  it('rejects create when not admin', async () => {
+    mockedPrisma.programYear.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc' });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'delegate' });
+    const res = await request(app)
+      .post('/program-years/1/delegates')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ firstName: 'John', lastName: 'Doe' });
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects list when not member', async () => {
+    mockedPrisma.programYear.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc' });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce(null);
+    const res = await request(app)
+      .get('/program-years/1/delegates')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 404 when updating missing delegate', async () => {
+    mockedPrisma.delegate.findUnique.mockResolvedValueOnce(null);
+    const res = await request(app)
+      .put('/delegates/1')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ firstName: 'Jane' });
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects update when not admin', async () => {
+    mockedPrisma.delegate.findUnique.mockResolvedValueOnce({ id: 1, programYearId: 1 });
+    mockedPrisma.programYear.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc' });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'delegate' });
+    const res = await request(app)
+      .put('/delegates/1')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ firstName: 'Jane' });
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 404 when deleting missing delegate', async () => {
+    mockedPrisma.delegate.findUnique.mockResolvedValueOnce(null);
+    const res = await request(app)
+      .delete('/delegates/1')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects delete when not admin', async () => {
+    mockedPrisma.delegate.findUnique.mockResolvedValueOnce({ id: 1, programYearId: 1 });
+    mockedPrisma.programYear.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc' });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'delegate' });
+    const res = await request(app)
+      .delete('/delegates/1')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(403);
+  });
+});

--- a/__tests__/elections.error.test.ts
+++ b/__tests__/elections.error.test.ts
@@ -1,0 +1,127 @@
+import request from 'supertest';
+jest.mock('../src/prisma');
+import prisma from '../src/prisma';
+import app from '../src/index';
+import { sign } from '../src/jwt';
+
+const mockedPrisma = prisma as any;
+const token = sign({ userId: 1, email: 'admin@example.com' }, 'development-secret');
+
+beforeEach(() => {
+  mockedPrisma.programAssignment.findFirst.mockReset();
+  mockedPrisma.programYear.findUnique.mockReset();
+  mockedPrisma.election.findUnique.mockReset();
+  mockedPrisma.election.update.mockReset();
+  mockedPrisma.election.create.mockReset();
+  mockedPrisma.electionVote.create.mockReset();
+});
+
+describe('Election error cases', () => {
+  it('rejects create when not admin', async () => {
+    mockedPrisma.programYear.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc' });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'delegate' });
+    const res = await request(app)
+      .post('/program-years/1/elections')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ positionId: 1, groupingId: 2, method: 'plurality' });
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 404 when program year missing', async () => {
+    mockedPrisma.programYear.findUnique.mockResolvedValueOnce(null);
+    const res = await request(app)
+      .post('/program-years/1/elections')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ positionId: 1, groupingId: 2, method: 'plurality' });
+    expect(res.status).toBe(404);
+  });
+
+  it('requires required fields', async () => {
+    mockedPrisma.programYear.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc' });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'admin' });
+    const res = await request(app)
+      .post('/program-years/1/elections')
+      .set('Authorization', `Bearer ${token}`)
+      .send({});
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects get elections when not member', async () => {
+    mockedPrisma.programYear.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc' });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce(null);
+    const res = await request(app)
+      .get('/program-years/1/elections')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 404 when updating missing election', async () => {
+    mockedPrisma.election.findUnique.mockResolvedValueOnce(null);
+    const res = await request(app)
+      .put('/elections/1')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ status: 'closed' });
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects update when not admin', async () => {
+    mockedPrisma.election.findUnique.mockResolvedValueOnce({ id: 1, programYearId: 1 });
+    mockedPrisma.programYear.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc' });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'delegate' });
+    const res = await request(app)
+      .put('/elections/1')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ status: 'closed' });
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 404 when deleting missing election', async () => {
+    mockedPrisma.election.findUnique.mockResolvedValueOnce(null);
+    const res = await request(app)
+      .delete('/elections/1')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects delete when not admin', async () => {
+    mockedPrisma.election.findUnique.mockResolvedValueOnce({ id: 1, programYearId: 1 });
+    mockedPrisma.programYear.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc' });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'delegate' });
+    const res = await request(app)
+      .delete('/elections/1')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects vote when not member', async () => {
+    mockedPrisma.election.findUnique.mockResolvedValueOnce({ id: 1, programYearId: 1 });
+    mockedPrisma.programYear.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc' });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce(null);
+    const res = await request(app)
+      .post('/elections/1/vote')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ candidateId: 2, voterId: 3 });
+    expect(res.status).toBe(403);
+  });
+
+  it('requires candidate and voter ids when voting', async () => {
+    mockedPrisma.election.findUnique.mockResolvedValueOnce({ id: 1, programYearId: 1 });
+    mockedPrisma.programYear.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc' });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'delegate' });
+    const res = await request(app)
+      .post('/elections/1/vote')
+      .set('Authorization', `Bearer ${token}`)
+      .send({});
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects results when not member', async () => {
+    mockedPrisma.election.findUnique.mockResolvedValueOnce({ id: 1, programYearId: 1 });
+    mockedPrisma.programYear.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc' });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce(null);
+    const res = await request(app)
+      .get('/elections/1/results')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(403);
+  });
+});

--- a/__tests__/groupingTypes.error.test.ts
+++ b/__tests__/groupingTypes.error.test.ts
@@ -1,0 +1,60 @@
+import request from 'supertest';
+jest.mock('../src/prisma');
+import prisma from '../src/prisma';
+import app from '../src/index';
+import { sign } from '../src/jwt';
+
+const mockedPrisma = prisma as any;
+const token = sign({ userId: 1, email: 'admin@example.com' }, 'development-secret');
+
+beforeEach(() => {
+  mockedPrisma.programAssignment.findFirst.mockReset();
+  mockedPrisma.groupingType.findUnique.mockReset();
+  mockedPrisma.groupingType.update.mockReset();
+});
+
+describe('GroupingType error cases', () => {
+  it('rejects create when not admin', async () => {
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'delegate' });
+    const res = await request(app)
+      .post('/programs/abc/grouping-types')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ defaultName: 'City', levelOrder: 1 });
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects listing when not member', async () => {
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce(null);
+    const res = await request(app)
+      .get('/programs/abc/grouping-types')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects update when not admin', async () => {
+    mockedPrisma.groupingType.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc' });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'delegate' });
+    const res = await request(app)
+      .put('/grouping-types/1')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ customName: 'Town' });
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 404 when deleting missing type', async () => {
+    mockedPrisma.groupingType.findUnique.mockResolvedValueOnce(null);
+    const res = await request(app)
+      .delete('/grouping-types/1')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects delete when not admin', async () => {
+    mockedPrisma.groupingType.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc' });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'delegate' });
+    const res = await request(app)
+      .delete('/grouping-types/1')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(403);
+  });
+});

--- a/__tests__/groupings.error.test.ts
+++ b/__tests__/groupings.error.test.ts
@@ -1,0 +1,100 @@
+import request from 'supertest';
+jest.mock('../src/prisma');
+import prisma from '../src/prisma';
+import app from '../src/index';
+import { sign } from '../src/jwt';
+
+const mockedPrisma = prisma as any;
+const token = sign({ userId: 1, email: 'admin@example.com' }, 'development-secret');
+
+beforeEach(() => {
+  mockedPrisma.programAssignment.findFirst.mockReset();
+  mockedPrisma.grouping.findUnique.mockReset();
+  mockedPrisma.grouping.update.mockReset();
+  mockedPrisma.programYear.findUnique.mockReset();
+  mockedPrisma.programYearGrouping.create.mockReset();
+});
+
+describe('Grouping error cases', () => {
+  it('rejects create when not admin', async () => {
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'delegate' });
+    const res = await request(app)
+      .post('/programs/abc/groupings')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ groupingTypeId: 1, name: 'Town 1' });
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects list when not member', async () => {
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce(null);
+    const res = await request(app)
+      .get('/programs/abc/groupings')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 404 when updating missing grouping', async () => {
+    mockedPrisma.grouping.findUnique.mockResolvedValueOnce(null);
+    const res = await request(app)
+      .put('/groupings/1')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'Updated' });
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects update when not admin', async () => {
+    mockedPrisma.grouping.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc' });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'delegate' });
+    const res = await request(app)
+      .put('/groupings/1')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'Updated' });
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 404 when deleting missing grouping', async () => {
+    mockedPrisma.grouping.findUnique.mockResolvedValueOnce(null);
+    const res = await request(app)
+      .delete('/groupings/1')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects delete when not admin', async () => {
+    mockedPrisma.grouping.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc' });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'delegate' });
+    const res = await request(app)
+      .delete('/groupings/1')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects activation when not admin', async () => {
+    mockedPrisma.programYear.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc' });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'delegate' });
+    const res = await request(app)
+      .post('/program-years/1/groupings/activate')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ groupingIds: [1] });
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects activation with missing ids', async () => {
+    mockedPrisma.programYear.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc' });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'admin' });
+    const res = await request(app)
+      .post('/program-years/1/groupings/activate')
+      .set('Authorization', `Bearer ${token}`)
+      .send({});
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects program year groupings list when not member', async () => {
+    mockedPrisma.programYear.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc' });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce(null);
+    const res = await request(app)
+      .get('/program-years/1/groupings')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(403);
+  });
+});

--- a/__tests__/parents.error.test.ts
+++ b/__tests__/parents.error.test.ts
@@ -1,0 +1,97 @@
+import request from 'supertest';
+jest.mock('../src/prisma');
+import prisma from '../src/prisma';
+import app from '../src/index';
+import { sign } from '../src/jwt';
+
+const mockedPrisma = prisma as any;
+const token = sign({ userId: 1, email: 'admin@example.com' }, 'development-secret');
+
+beforeEach(() => {
+  mockedPrisma.programAssignment.findFirst.mockReset();
+  mockedPrisma.parent.findUnique.mockReset();
+  mockedPrisma.parent.update.mockReset();
+  mockedPrisma.parent.create.mockReset();
+  mockedPrisma.delegateParentLink.findUnique.mockReset();
+  mockedPrisma.delegateParentLink.update.mockReset();
+});
+
+describe('Parent error cases', () => {
+  it('rejects create when not admin', async () => {
+    mockedPrisma.programYear.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc' });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'delegate' });
+    const res = await request(app)
+      .post('/program-years/1/parents')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ firstName: 'Jane' });
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects list when not member', async () => {
+    mockedPrisma.programYear.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc' });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce(null);
+    const res = await request(app)
+      .get('/program-years/1/parents')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 404 when updating missing parent', async () => {
+    mockedPrisma.parent.findUnique.mockResolvedValueOnce(null);
+    const res = await request(app)
+      .put('/parents/1')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ firstName: 'Janet' });
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects update when not admin', async () => {
+    mockedPrisma.parent.findUnique.mockResolvedValueOnce({ id: 1, programYearId: 1 });
+    mockedPrisma.programYear.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc' });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'delegate' });
+    const res = await request(app)
+      .put('/parents/1')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ firstName: 'Janet' });
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 404 when removing missing parent', async () => {
+    mockedPrisma.parent.findUnique.mockResolvedValueOnce(null);
+    const res = await request(app)
+      .delete('/parents/1')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects remove when not admin', async () => {
+    mockedPrisma.parent.findUnique.mockResolvedValueOnce({ id: 1, programYearId: 1 });
+    mockedPrisma.programYear.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc' });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'delegate' });
+    const res = await request(app)
+      .delete('/parents/1')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects link create when not admin', async () => {
+    mockedPrisma.programYear.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc' });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'delegate' });
+    const res = await request(app)
+      .post('/delegate-parent-links')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ delegateId: 2, parentId: 3, programYearId: 1 });
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects link update when not admin', async () => {
+    mockedPrisma.delegateParentLink.findUnique.mockResolvedValueOnce({ id: 1, programYearId: 1 });
+    mockedPrisma.programYear.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc' });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'delegate' });
+    const res = await request(app)
+      .put('/delegate-parent-links/1')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ status: 'accepted' });
+    expect(res.status).toBe(403);
+  });
+});

--- a/__tests__/parties.error.test.ts
+++ b/__tests__/parties.error.test.ts
@@ -1,0 +1,107 @@
+import request from 'supertest';
+jest.mock('../src/prisma');
+import prisma from '../src/prisma';
+import app from '../src/index';
+import { sign } from '../src/jwt';
+
+const mockedPrisma = prisma as any;
+const token = sign({ userId: 1, email: 'admin@example.com' }, 'development-secret');
+
+beforeEach(() => {
+  mockedPrisma.programAssignment.findFirst.mockReset();
+  mockedPrisma.programYear.findUnique.mockReset();
+  mockedPrisma.party.findUnique.mockReset();
+});
+
+describe('Party error cases', () => {
+  it('rejects create when not admin', async () => {
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'delegate' });
+    const res = await request(app)
+      .post('/programs/abc/parties')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'A' });
+    expect(res.status).toBe(403);
+  });
+
+  it('requires name when creating', async () => {
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'admin' });
+    const res = await request(app)
+      .post('/programs/abc/parties')
+      .set('Authorization', `Bearer ${token}`)
+      .send({});
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects list when not member', async () => {
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce(null);
+    const res = await request(app)
+      .get('/programs/abc/parties')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 404 when updating missing party', async () => {
+    mockedPrisma.party.findUnique.mockResolvedValueOnce(null);
+    const res = await request(app)
+      .put('/parties/1')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'B' });
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects update when not admin', async () => {
+    mockedPrisma.party.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc' });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'delegate' });
+    const res = await request(app)
+      .put('/parties/1')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'B' });
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 404 when deleting missing party', async () => {
+    mockedPrisma.party.findUnique.mockResolvedValueOnce(null);
+    const res = await request(app)
+      .delete('/parties/1')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects delete when not admin', async () => {
+    mockedPrisma.party.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc' });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'delegate' });
+    const res = await request(app)
+      .delete('/parties/1')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects activation when not admin', async () => {
+    mockedPrisma.programYear.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc' });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'delegate' });
+    const res = await request(app)
+      .post('/program-years/1/parties/activate')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ partyIds: [1] });
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects activation with missing ids', async () => {
+    mockedPrisma.programYear.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc' });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'admin' });
+    const res = await request(app)
+      .post('/program-years/1/parties/activate')
+      .set('Authorization', `Bearer ${token}`)
+      .send({});
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects program year parties list when not member', async () => {
+    mockedPrisma.programYear.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc' });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce(null);
+    const res = await request(app)
+      .get('/program-years/1/parties')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(403);
+  });
+});

--- a/__tests__/positions.error.test.ts
+++ b/__tests__/positions.error.test.ts
@@ -1,0 +1,79 @@
+import request from 'supertest';
+jest.mock('../src/prisma');
+import prisma from '../src/prisma';
+import app from '../src/index';
+import { sign } from '../src/jwt';
+
+const mockedPrisma = prisma as any;
+const token = sign({ userId: 1, email: 'admin@example.com' }, 'development-secret');
+
+beforeEach(() => {
+  mockedPrisma.programAssignment.findFirst.mockReset();
+  mockedPrisma.position.findUnique.mockReset();
+  mockedPrisma.position.update.mockReset();
+  mockedPrisma.position.create.mockReset();
+});
+
+describe('Position error cases', () => {
+  it('rejects create when not admin', async () => {
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'delegate' });
+    const res = await request(app)
+      .post('/programs/abc/positions')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'Gov' });
+    expect(res.status).toBe(403);
+  });
+
+  it('requires name when creating', async () => {
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'admin' });
+    const res = await request(app)
+      .post('/programs/abc/positions')
+      .set('Authorization', `Bearer ${token}`)
+      .send({});
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects list when not member', async () => {
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce(null);
+    const res = await request(app)
+      .get('/programs/abc/positions')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 404 when updating missing position', async () => {
+    mockedPrisma.position.findUnique.mockResolvedValueOnce(null);
+    const res = await request(app)
+      .put('/positions/1')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'New' });
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects update when not admin', async () => {
+    mockedPrisma.position.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc' });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'delegate' });
+    const res = await request(app)
+      .put('/positions/1')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'New' });
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 404 when deleting missing position', async () => {
+    mockedPrisma.position.findUnique.mockResolvedValueOnce(null);
+    const res = await request(app)
+      .delete('/positions/1')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects delete when not admin', async () => {
+    mockedPrisma.position.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc' });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'delegate' });
+    const res = await request(app)
+      .delete('/positions/1')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(403);
+  });
+});

--- a/__tests__/programYearPositions.error.test.ts
+++ b/__tests__/programYearPositions.error.test.ts
@@ -1,0 +1,84 @@
+import request from 'supertest';
+jest.mock('../src/prisma');
+import prisma from '../src/prisma';
+import app from '../src/index';
+import { sign } from '../src/jwt';
+
+const mockedPrisma = prisma as any;
+const token = sign({ userId: 1, email: 'admin@example.com' }, 'development-secret');
+
+beforeEach(() => {
+  mockedPrisma.programAssignment.findFirst.mockReset();
+  mockedPrisma.programYear.findUnique.mockReset();
+  mockedPrisma.programYearPosition.findUnique.mockReset();
+  mockedPrisma.programYearPosition.update.mockReset();
+  mockedPrisma.programYearPosition.create.mockReset();
+});
+
+describe('ProgramYearPosition error cases', () => {
+  it('rejects create when not admin', async () => {
+    mockedPrisma.programYear.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc' });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'delegate' });
+    const res = await request(app)
+      .post('/program-years/1/positions')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ positionId: 2 });
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 404 when program year missing', async () => {
+    mockedPrisma.programYear.findUnique.mockResolvedValueOnce(null);
+    const res = await request(app)
+      .post('/program-years/1/positions')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ positionId: 2 });
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects list when not member', async () => {
+    mockedPrisma.programYear.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc' });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce(null);
+    const res = await request(app)
+      .get('/program-years/1/positions')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 404 when updating missing record', async () => {
+    mockedPrisma.programYearPosition.findUnique.mockResolvedValueOnce(null);
+    const res = await request(app)
+      .put('/program-year-positions/1')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ delegateId: 5 });
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects update when not admin', async () => {
+    mockedPrisma.programYearPosition.findUnique.mockResolvedValueOnce({ id: 1, programYearId: 1 });
+    mockedPrisma.programYear.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc' });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'delegate' });
+    const res = await request(app)
+      .put('/program-year-positions/1')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ delegateId: 5 });
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 404 when deleting missing record', async () => {
+    mockedPrisma.programYearPosition.findUnique.mockResolvedValueOnce(null);
+    const res = await request(app)
+      .delete('/program-year-positions/1')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects delete when not admin', async () => {
+    mockedPrisma.programYearPosition.findUnique.mockResolvedValueOnce({ id: 1, programYearId: 1 });
+    mockedPrisma.programYear.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc' });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'delegate' });
+    const res = await request(app)
+      .delete('/program-year-positions/1')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(403);
+  });
+});

--- a/__tests__/programYears.error.test.ts
+++ b/__tests__/programYears.error.test.ts
@@ -1,0 +1,79 @@
+import request from 'supertest';
+jest.mock('../src/prisma');
+import prisma from '../src/prisma';
+import app from '../src/index';
+import { sign } from '../src/jwt';
+
+const mockedPrisma = prisma as any;
+const token = sign({ userId: 1, email: 'admin@example.com' }, 'development-secret');
+
+beforeEach(() => {
+  mockedPrisma.programAssignment.findFirst.mockReset();
+  mockedPrisma.programYear.findUnique.mockReset();
+  mockedPrisma.programYear.update.mockReset();
+  mockedPrisma.programYear.create.mockReset();
+});
+
+describe('ProgramYear error cases', () => {
+  it('rejects create when not admin', async () => {
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'delegate' });
+    const res = await request(app)
+      .post('/programs/abc/years')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ year: 2025 });
+    expect(res.status).toBe(403);
+  });
+
+  it('requires year when creating', async () => {
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'admin' });
+    const res = await request(app)
+      .post('/programs/abc/years')
+      .set('Authorization', `Bearer ${token}`)
+      .send({});
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects list when not member', async () => {
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce(null);
+    const res = await request(app)
+      .get('/programs/abc/years')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 404 when updating missing year', async () => {
+    mockedPrisma.programYear.findUnique.mockResolvedValueOnce(null);
+    const res = await request(app)
+      .put('/program-years/1')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ status: 'archived' });
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects update when not admin', async () => {
+    mockedPrisma.programYear.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc' });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'delegate' });
+    const res = await request(app)
+      .put('/program-years/1')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ status: 'archived' });
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 404 when deleting missing year', async () => {
+    mockedPrisma.programYear.findUnique.mockResolvedValueOnce(null);
+    const res = await request(app)
+      .delete('/program-years/1')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects delete when not admin', async () => {
+    mockedPrisma.programYear.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc' });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'delegate' });
+    const res = await request(app)
+      .delete('/program-years/1')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(403);
+  });
+});

--- a/__tests__/programs.error.test.ts
+++ b/__tests__/programs.error.test.ts
@@ -1,0 +1,62 @@
+import request from 'supertest';
+jest.mock('../src/prisma');
+import prisma from '../src/prisma';
+import app from '../src/index';
+import { sign } from '../src/jwt';
+
+const mockedPrisma = prisma as any;
+const token = sign({ userId: 1, email: 'admin@example.com' }, 'development-secret');
+
+beforeEach(() => {
+  mockedPrisma.programAssignment.findFirst.mockReset();
+  mockedPrisma.program.findUnique.mockReset();
+  mockedPrisma.program.update.mockReset();
+  mockedPrisma.program.create.mockReset();
+});
+
+describe('Program error cases', () => {
+  it('rejects program creation when missing fields', async () => {
+    mockedPrisma.program.create.mockResolvedValueOnce({ id: 'p1', name: 'Test', year: 2025 });
+    const res = await request(app)
+      .post('/programs')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'Test' });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects user assignment when not admin', async () => {
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'delegate' });
+    const res = await request(app)
+      .post('/programs/abc/users')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ userId: 2, role: 'counselor' });
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects listing users when not admin', async () => {
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'delegate' });
+    const res = await request(app)
+      .get('/programs/abc/users')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 404 when updating missing program', async () => {
+    mockedPrisma.program.findUnique.mockResolvedValueOnce(null);
+    const res = await request(app)
+      .put('/programs/abc')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'New' });
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects update when not admin', async () => {
+    mockedPrisma.program.findUnique.mockResolvedValueOnce({ id: 'abc' });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'delegate' });
+    const res = await request(app)
+      .put('/programs/abc')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'New' });
+    expect(res.status).toBe(403);
+  });
+});

--- a/__tests__/staff.error.test.ts
+++ b/__tests__/staff.error.test.ts
@@ -1,0 +1,83 @@
+import request from 'supertest';
+jest.mock('../src/prisma');
+import prisma from '../src/prisma';
+import app from '../src/index';
+import { sign } from '../src/jwt';
+
+const mockedPrisma = prisma as any;
+const token = sign({ userId: 1, email: 'admin@example.com' }, 'development-secret');
+
+beforeEach(() => {
+  mockedPrisma.programAssignment.findFirst.mockReset();
+  mockedPrisma.programYear.findUnique.mockReset();
+  mockedPrisma.staff.findUnique.mockReset();
+});
+
+describe('Staff error cases', () => {
+  it('rejects create when not admin', async () => {
+    mockedPrisma.programYear.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc' });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'delegate' });
+    const res = await request(app)
+      .post('/program-years/1/staff')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ firstName: 'A', lastName: 'B', email: 'a@b.c', role: 'counselor' });
+    expect(res.status).toBe(403);
+  });
+
+  it('requires fields when creating', async () => {
+    mockedPrisma.programYear.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc' });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'admin' });
+    const res = await request(app)
+      .post('/program-years/1/staff')
+      .set('Authorization', `Bearer ${token}`)
+      .send({});
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects list when not member', async () => {
+    mockedPrisma.programYear.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc' });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce(null);
+    const res = await request(app)
+      .get('/program-years/1/staff')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 404 when updating missing staff', async () => {
+    mockedPrisma.staff.findUnique.mockResolvedValueOnce(null);
+    const res = await request(app)
+      .put('/staff/1')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ role: 'counselor' });
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects update when not admin', async () => {
+    mockedPrisma.staff.findUnique.mockResolvedValueOnce({ id: 1, programYearId: 1 });
+    mockedPrisma.programYear.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc' });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'delegate' });
+    const res = await request(app)
+      .put('/staff/1')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ role: 'counselor' });
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 404 when deleting missing staff', async () => {
+    mockedPrisma.staff.findUnique.mockResolvedValueOnce(null);
+    const res = await request(app)
+      .delete('/staff/1')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects delete when not admin', async () => {
+    mockedPrisma.staff.findUnique.mockResolvedValueOnce({ id: 1, programYearId: 1 });
+    mockedPrisma.programYear.findUnique.mockResolvedValueOnce({ id: 1, programId: 'abc' });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'delegate' });
+    const res = await request(app)
+      .delete('/staff/1')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(403);
+  });
+});

--- a/dist/routes/programYears.js
+++ b/dist/routes/programYears.js
@@ -36,7 +36,6 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-/* istanbul ignore file */
 const express_1 = __importDefault(require("express"));
 const prisma_1 = __importDefault(require("../prisma"));
 const logger = __importStar(require("../logger"));

--- a/dist/routes/programs.js
+++ b/dist/routes/programs.js
@@ -36,7 +36,6 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-/* istanbul ignore file */
 const express_1 = __importDefault(require("express"));
 const prisma_1 = __importDefault(require("../prisma"));
 const logger = __importStar(require("../logger"));


### PR DESCRIPTION
## Summary
- expand Jest tests with extensive error coverage
- include auth utility tests
- regenerate dist build

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_686e5a5c1438832dabd98dbec7377bdb