### PR TITLE
Improve OpenAPI endpoint descriptions

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -335,6 +335,9 @@ paths:
     post:
       tags: [system]
       summary: Create an audit log entry
+      description: >-
+        Records an audit entry describing a change made to a database record.
+        Used for compliance tracking.
       requestBody:
         required: true
         content:
@@ -363,6 +366,9 @@ paths:
     get:
       tags: [system]
       summary: List audit log entries
+      description: >-
+        Returns audit entries filtered by table, record, user, or date range.
+        Results are paginated and sorted by newest first.
       parameters:
         - in: query
           name: tableName
@@ -405,6 +411,9 @@ paths:
     get:
       tags: [programs]
       summary: List all programs
+      description: >-
+        Returns every program in the system. The caller must be authenticated
+        but does not need to belong to any specific program.
       responses:
         '200':
           description: Array of programs
@@ -413,6 +422,9 @@ paths:
     post:
       tags: [programs]
       summary: Create a new program
+      description: >-
+        Creates a program record and assigns the requesting user as an admin of
+        that program.
       requestBody:
         required: true
         content:
@@ -465,6 +477,9 @@ paths:
     get:
       tags: [programs]
       summary: Get program details
+      description: >-
+        Retrieves the program record specified by `id`. The requester must be
+        assigned to the program or an admin.
       parameters:
         - in: path
           name: id
@@ -483,6 +498,9 @@ paths:
     put:
       tags: [programs]
       summary: Update program
+      description: >-
+        Updates basic program information such as name, year, or status. Only
+        program admins may call this endpoint.
       parameters:
         - in: path
           name: id
@@ -516,6 +534,9 @@ paths:
     delete:
       tags: [programs]
       summary: Retire program
+      description: >-
+        Marks the program as retired without deleting the data. Only admins can
+        retire a program.
       parameters:
         - in: path
           name: id
@@ -535,6 +556,9 @@ paths:
     get:
       tags: [programs]
       summary: Get program branding and contact info
+      description: >-
+        Returns branding colors, logos, and contact information for the
+        specified program. Requires membership in the program.
       parameters:
         - in: path
           name: id
@@ -553,6 +577,9 @@ paths:
     put:
       tags: [programs]
       summary: Update program branding and contact info
+      description: >-
+        Updates branding and contact fields for the program such as colors,
+        welcome message, and support contacts. Only admins may update branding.
       parameters:
         - in: path
           name: id
@@ -578,6 +605,10 @@ paths:
     get:
       tags: [programs]
       summary: Get full program configuration
+      description: >-
+        Retrieves all configuration settings for the specified program,
+        including feature toggles and branding. Requires membership in the
+        program.
       parameters:
         - in: path
           name: id
@@ -597,6 +628,9 @@ paths:
     post:
       tags: [programs]
       summary: Assign user to program
+      description: >-
+        Adds a user to a program with the specified role. Caller must be a
+        program admin.
       parameters:
         - in: path
           name: programId
@@ -650,6 +684,9 @@ paths:
     get:
       tags: [programs]
       summary: List users in program
+      description: >-
+        Returns all users assigned to the program along with their roles.
+        Requires admin access to the program.
       parameters:
         - in: path
           name: programId
@@ -679,6 +716,9 @@ paths:
     post:
       tags: [programs]
       summary: Create program year
+      description: >-
+        Adds a new year entry to the program. This is typically used at the
+        start of a new session. Admin privileges are required.
       parameters:
         - in: path
           name: programId
@@ -719,6 +759,9 @@ paths:
     get:
       tags: [programs]
       summary: List program years
+      description: >-
+        Returns all years that have been configured for the program. Requires
+        membership in the program.
       parameters:
         - in: path
           name: programId
@@ -743,6 +786,9 @@ paths:
     post:
       tags: [groupingTypes]
       summary: Add grouping type
+      description: >-
+        Creates a new grouping type for organizing delegates (for example,
+        city, county, or district). Admin privileges are required.
       parameters:
         - in: path
           name: programId
@@ -780,6 +826,9 @@ paths:
     get:
       tags: [groupingTypes]
       summary: List grouping types
+      description: >-
+        Lists all grouping type definitions for the program in ascending order
+        by level. Requires program membership.
       parameters:
         - in: path
           name: programId
@@ -804,6 +853,9 @@ paths:
     put:
       tags: [groupingTypes]
       summary: Update grouping type
+      description: >-
+        Modifies the grouping type definition such as its display name or
+        whether it is required. Only program admins can update a grouping type.
       parameters:
         - in: path
           name: id
@@ -839,6 +891,9 @@ paths:
     delete:
       tags: [groupingTypes]
       summary: Retire grouping type
+      description: >-
+        Marks the grouping type as retired so it can no longer be used for new
+        groupings. Only admins may retire a type.
       parameters:
         - in: path
           name: id
@@ -858,6 +913,9 @@ paths:
     post:
       tags: [groupings]
       summary: Add grouping
+      description: >-
+        Creates a new grouping (for example a city or county) under the
+        specified program. Requires admin permissions.
       parameters:
         - in: path
           name: programId
@@ -895,6 +953,9 @@ paths:
     get:
       tags: [groupings]
       summary: List groupings
+      description: >-
+        Returns all groupings defined for the program. Caller must be a member
+        of the program.
       parameters:
         - in: path
           name: programId
@@ -919,6 +980,9 @@ paths:
     put:
       tags: [groupings]
       summary: Update grouping
+      description: >-
+        Updates the specified grouping's name, parent, or status. Admin access
+        to the grouping's program is required.
       parameters:
         - in: path
           name: id
@@ -954,6 +1018,9 @@ paths:
     delete:
       tags: [groupings]
       summary: Retire grouping
+      description: >-
+        Retires the grouping so it can no longer be assigned to delegates. Only
+        program admins may perform this action.
       parameters:
         - in: path
           name: id
@@ -973,6 +1040,9 @@ paths:
     post:
       tags: [groupings]
       summary: Activate groupings for year
+      description: >-
+        Activates a set of groupings for the specified program year so they can
+        be assigned to delegates. Requires admin rights.
       parameters:
         - in: path
           name: id
@@ -1007,6 +1077,9 @@ paths:
     get:
       tags: [groupings]
       summary: List active groupings for year
+      description: >-
+        Lists the groupings that are active for the given program year.
+        Membership in the program is required.
       parameters:
         - in: path
           name: id
@@ -1033,6 +1106,8 @@ paths:
     post:
       tags: [parties]
       summary: Add party
+      description: >-
+        Creates a political party for the program. Admin access is required.
       parameters:
         - in: path
           name: programId
@@ -1070,6 +1145,9 @@ paths:
     get:
       tags: [parties]
       summary: List parties
+      description: >-
+        Lists all party definitions for the program. Caller must belong to the
+        program.
       parameters:
         - in: path
           name: programId
@@ -1094,6 +1172,9 @@ paths:
     put:
       tags: [parties]
       summary: Update party
+      description: >-
+        Updates party details such as name, abbreviation, or icon. Only admins
+        may modify parties.
       parameters:
         - in: path
           name: id
@@ -1131,6 +1212,9 @@ paths:
     delete:
       tags: [parties]
       summary: Retire party
+      description: >-
+        Marks the party as retired. Existing assignments remain but new ones
+        cannot be created. Admin only.
       parameters:
         - in: path
           name: id
@@ -1150,6 +1234,9 @@ paths:
     post:
       tags: [parties]
       summary: Activate parties for year
+      description: >-
+        Enables a subset of parties for the given program year. Parties must be
+        created first. Admin access required.
       parameters:
         - in: path
           name: id
@@ -1184,6 +1271,9 @@ paths:
     get:
       tags: [parties]
       summary: List active parties for year
+      description: >-
+        Returns parties that are active for the specified program year.
+        Membership in the program is required.
       parameters:
         - in: path
           name: id
@@ -1210,6 +1300,9 @@ paths:
     post:
       tags: [delegates]
       summary: Add delegate
+      description: >-
+        Creates a new delegate record for the specified program year. Admin
+        access is required.
       parameters:
         - in: path
           name: id
@@ -1253,6 +1346,9 @@ paths:
     get:
       tags: [delegates]
       summary: List delegates for year
+      description: >-
+        Returns all delegates registered for the given program year. Requires
+        membership in the program.
       parameters:
         - in: path
           name: id
@@ -1279,6 +1375,9 @@ paths:
     put:
       tags: [delegates]
       summary: Update delegate
+      description: >-
+        Updates delegate information such as contact details or grouping
+        assignment. Only program admins can update delegates.
       parameters:
         - in: path
           name: id
@@ -1320,6 +1419,9 @@ paths:
     delete:
       tags: [delegates]
       summary: Withdraw delegate
+      description: >-
+        Marks the delegate as withdrawn from the program year. Admin rights are
+        required.
       parameters:
         - in: path
           name: id
@@ -1339,6 +1441,9 @@ paths:
     post:
       tags: [staff]
       summary: Add staff member
+      description: >-
+        Adds a staff member to the specified program year. Admin permissions are
+        required.
       parameters:
         - in: path
           name: id
@@ -1382,6 +1487,9 @@ paths:
     get:
       tags: [staff]
       summary: List staff for year
+      description: >-
+        Returns all staff members assigned to the program year. Caller must be a
+        program member.
       parameters:
         - in: path
           name: id
@@ -1408,6 +1516,9 @@ paths:
     put:
       tags: [staff]
       summary: Update staff member
+      description: >-
+        Updates staff details or role assignments. Only admins can update staff
+        records.
       parameters:
         - in: path
           name: id
@@ -1449,6 +1560,9 @@ paths:
     delete:
       tags: [staff]
       summary: Remove staff member
+      description: >-
+        Removes a staff member from the program year. Admin permissions
+        required.
       parameters:
         - in: path
           name: id
@@ -1466,6 +1580,9 @@ paths:
     post:
       tags: [positions]
       summary: Add position
+      description: >-
+        Creates a position (such as an elected office) that delegates can hold.
+        Admin access required.
       parameters:
         - in: path
           name: programId
@@ -1499,6 +1616,9 @@ paths:
     get:
       tags: [positions]
       summary: List positions
+      description: >-
+        Lists all position definitions for the program. Requires program
+        membership.
       parameters:
         - in: path
           name: programId
@@ -1523,6 +1643,9 @@ paths:
     put:
       tags: [positions]
       summary: Update position
+      description: >-
+        Updates a position's details or display order. Only admins may update
+        positions.
       parameters:
         - in: path
           name: id
@@ -1556,6 +1679,9 @@ paths:
     delete:
       tags: [positions]
       summary: Retire position
+      description: >-
+        Retires the position so it can no longer be assigned. Admin access
+        required.
       parameters:
         - in: path
           name: id
@@ -1575,6 +1701,9 @@ paths:
     post:
       tags: [positions]
       summary: Assign position to year
+      description: >-
+        Activates a position for a specific program year and optionally assigns
+        an initial delegate.
       parameters:
         - in: path
           name: id
@@ -1608,6 +1737,9 @@ paths:
     get:
       tags: [positions]
       summary: List program year positions
+      description: >-
+        Returns all position assignments for the program year. Caller must be a
+        program member.
       parameters:
         - in: path
           name: id
@@ -1634,6 +1766,9 @@ paths:
     put:
       tags: [positions]
       summary: Update program year position
+      description: >-
+        Updates the delegate or status of a program year position. Admin
+        privileges required.
       parameters:
         - in: path
           name: id
@@ -1665,6 +1800,9 @@ paths:
     post:
       tags: [elections]
       summary: Create election
+      description: >-
+        Creates a new election for a position within the program year.
+        Requires admin access and specifies the voting method and timeframe.
       parameters:
         - in: path
           name: id
@@ -1706,6 +1844,9 @@ paths:
     get:
       tags: [elections]
       summary: List elections
+      description: >-
+        Lists all elections configured for the given program year. Caller must
+        be a program member.
       parameters:
         - in: path
           name: id
@@ -1733,6 +1874,9 @@ paths:
     put:
       tags: [elections]
       summary: Update election
+      description: >-
+        Updates election details such as status or end time. Only admins can
+        modify elections.
       parameters:
         - in: path
           name: id
@@ -1766,6 +1910,8 @@ paths:
     delete:
       tags: [elections]
       summary: Remove election
+      description: >-
+        Deletes an election and all associated votes. Admin only.
       parameters:
         - in: path
           name: id
@@ -1786,6 +1932,9 @@ paths:
     post:
       tags: [elections]
       summary: Cast vote
+      description: >-
+        Records a delegate's vote for the specified election. Voters must be
+        eligible for the election.
       parameters:
         - in: path
           name: id
@@ -1822,6 +1971,9 @@ paths:
     get:
       tags: [elections]
       summary: Get election results
+      description: >-
+        Retrieves tallied results for the election. Only admins or authorized
+        staff may view results.
       parameters:
         - in: path
           name: id
@@ -1840,6 +1992,9 @@ paths:
     delete:
       tags: [positions]
       summary: Remove program year position
+      description: >-
+        Deletes a position assignment from the program year. Only admins can
+        remove assignments.
       parameters:
         - in: path
           name: id
@@ -1860,6 +2015,9 @@ paths:
     post:
       tags: [parents]
       summary: Add parent
+      description: >-
+        Registers a parent account for the specified program year. Admins use
+        this to invite or create parent records.
       parameters:
         - in: path
           name: id
@@ -1899,6 +2057,9 @@ paths:
     get:
       tags: [parents]
       summary: List parents for year
+      description: >-
+        Returns all parent accounts linked to delegates in the program year.
+        Requires membership in the program.
       parameters:
         - in: path
           name: id
@@ -1925,6 +2086,9 @@ paths:
     put:
       tags: [parents]
       summary: Update parent
+      description: >-
+        Updates parent contact information or status. Only program admins can
+        update parents.
       parameters:
         - in: path
           name: id
@@ -1962,6 +2126,8 @@ paths:
     delete:
       tags: [parents]
       summary: Remove parent
+      description: >-
+        Removes the parent record from the program year. Admin access required.
       parameters:
         - in: path
           name: id
@@ -1981,6 +2147,9 @@ paths:
     post:
       tags: [parents]
       summary: Create delegate-parent link
+      description: >-
+        Links a delegate to a parent account. The caller must be an admin or
+        staff member.
       requestBody:
         required: true
         content:
@@ -2010,6 +2179,9 @@ paths:
     put:
       tags: [parents]
       summary: Update delegate-parent link
+      description: >-
+        Updates the status of an existing delegate-parent relationship. Admins
+        use this to accept or revoke links.
       parameters:
         - in: path
           name: id
@@ -2038,6 +2210,9 @@ paths:
     get:
       tags: [programs]
       summary: Get program year
+      description: >-
+        Retrieves details for a specific program year including dates and
+        status. Requires membership in the program.
       parameters:
         - in: path
           name: id
@@ -2056,6 +2231,9 @@ paths:
     put:
       tags: [programs]
       summary: Update program year
+      description: >-
+        Updates program year fields such as start/end dates or status. Only
+        program admins can modify a year.
       parameters:
         - in: path
           name: id
@@ -2091,6 +2269,8 @@ paths:
     delete:
       tags: [programs]
       summary: Archive program year
+      description: >-
+        Archives the program year, preventing further modifications. Admin only.
       parameters:
         - in: path
           name: id


### PR DESCRIPTION
## Summary
- expand the `openapi.yaml` descriptions for all API endpoints
- clarify behaviors for CRUD endpoints

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_686fa1f44154832dbaa2d43b63719db5