### PR TITLE
Drop programName from branding contact

### DIFF
--- a/__tests__/brandingContact.test.ts
+++ b/__tests__/brandingContact.test.ts
@@ -24,7 +24,7 @@ describe('GET /api/branding-contact/:programId', () => {
   it('returns config when member', async () => {
     mockedPrisma.program.findUnique.mockResolvedValueOnce({ id: 'abc' });
     mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({});
-    mockedPrisma.programBrandingContact.findFirst.mockResolvedValueOnce({ id: '1', programId: 'abc', programName: 'Test' });
+    mockedPrisma.programBrandingContact.findFirst.mockResolvedValueOnce({ id: '1', programId: 'abc' });
     const res = await request(app)
       .get('/api/branding-contact/abc')
       .set('Authorization', `Bearer ${token}`);
@@ -38,11 +38,11 @@ describe('POST /api/branding-contact/:programId', () => {
     mockedPrisma.program.findUnique.mockResolvedValueOnce({ id: 'abc' });
     mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'admin' });
     mockedPrisma.programBrandingContact.findFirst.mockResolvedValueOnce(null);
-    mockedPrisma.programBrandingContact.create.mockResolvedValueOnce({ id: '1', programId: 'abc', programName: 'Test' });
+    mockedPrisma.programBrandingContact.create.mockResolvedValueOnce({ id: '1', programId: 'abc' });
     const res = await request(app)
       .post('/api/branding-contact/abc')
       .set('Authorization', `Bearer ${token}`)
-      .send({ programName: 'Test' });
+      .send({});
     expect(res.status).toBe(201);
     expect(mockedPrisma.programBrandingContact.create).toHaveBeenCalled();
     expect(mockedPrisma.programBrandingContactAudit.create).toHaveBeenCalled();
@@ -54,11 +54,11 @@ describe('POST /api/branding-contact/:programId existing', () => {
     mockedPrisma.program.findUnique.mockResolvedValueOnce({ id: 'abc' });
     mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'admin' });
     mockedPrisma.programBrandingContact.findFirst.mockResolvedValueOnce({ id: '1', programId: 'abc' });
-    mockedPrisma.programBrandingContact.update.mockResolvedValueOnce({ id: '1', programId: 'abc', programName: 'Test2' });
+    mockedPrisma.programBrandingContact.update.mockResolvedValueOnce({ id: '1', programId: 'abc' });
     const res = await request(app)
       .post('/api/branding-contact/abc')
       .set('Authorization', `Bearer ${token}`)
-      .send({ programName: 'Test2' });
+      .send({});
     expect(res.status).toBe(200);
     expect(mockedPrisma.programBrandingContact.update).toHaveBeenCalled();
   });
@@ -94,7 +94,7 @@ describe('POST /api/branding-contact/:programId forbidden', () => {
     const res = await request(app)
       .post('/api/branding-contact/abc')
       .set('Authorization', `Bearer ${token}`)
-      .send({ programName: 'Test' });
+      .send({});
     expect(res.status).toBe(403);
   });
 });

--- a/dist/openapi.yaml
+++ b/dist/openapi.yaml
@@ -26,6 +26,8 @@ tags:
     description: Manage program staff
   - name: positions
     description: Manage program positions
+  - name: brandingContact
+    description: Manage branding and contact details
 
 paths:
   /health:
@@ -628,6 +630,77 @@ paths:
       responses:
         '200':
           description: Updated branding
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+      security:
+        - bearerAuth: []
+  /api/branding-contact/{programId}:
+    get:
+      tags: [brandingContact]
+      summary: Retrieve branding and contact configuration
+      parameters:
+        - in: path
+          name: programId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Branding/contact config
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+      security:
+        - bearerAuth: []
+    post:
+      tags: [brandingContact]
+      summary: Create or update branding/contact configuration
+      parameters:
+        - in: path
+          name: programId
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '201':
+          description: Created configuration
+        '200':
+          description: Updated configuration
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+      security:
+        - bearerAuth: []
+    put:
+      tags: [brandingContact]
+      summary: Create or update branding/contact configuration
+      parameters:
+        - in: path
+          name: programId
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '201':
+          description: Created configuration
+        '200':
+          description: Updated configuration
         '403':
           description: Forbidden
         '404':

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -351,7 +351,6 @@ model ProgramBrandingContact {
   id                String   @id @default(cuid())
   program           Program  @relation(fields: [programId], references: [id])
   programId         String
-  programName       String
   welcomeMessage    String?
   logoUrl           String?
   iconUrl           String?

--- a/src/routes/brandingContact.ts
+++ b/src/routes/brandingContact.ts
@@ -32,7 +32,6 @@ async function saveBrandingContact(req: express.Request, res: express.Response) 
     return;
   }
   const {
-    programName,
     welcomeMessage,
     branding,
     colors,
@@ -42,7 +41,6 @@ async function saveBrandingContact(req: express.Request, res: express.Response) 
 
   const data = {
     programId,
-    programName,
     welcomeMessage,
     logoUrl: branding?.logoUrl,
     iconUrl: branding?.iconUrl,
@@ -77,7 +75,7 @@ async function saveBrandingContact(req: express.Request, res: express.Response) 
     data: {
       brandingContactId: record.id,
       programId,
-      programName: record.programName,
+      programName: program.name,
       welcomeMessage: record.welcomeMessage ?? undefined,
       logoUrl: record.logoUrl ?? undefined,
       iconUrl: record.iconUrl ?? undefined,
@@ -98,7 +96,7 @@ async function saveBrandingContact(req: express.Request, res: express.Response) 
   });
 
   logger.info(programId, `Branding/contact ${changeType}d by ${caller.email}`);
-  res.status(existing ? 200 : 201).json(record);
+  res.status(existing ? 200 : 201).json({ ...record, programName: program.name });
 }
 
 router.post('/api/branding-contact/:programId', saveBrandingContact);
@@ -134,7 +132,7 @@ router.get('/api/branding-contact/:programId', async (req, res) => {
     res.status(404).json({ error: 'Not found' });
     return;
   }
-  res.json(record);
+  res.json({ ...record, programName: program.name });
 });
 
 export default router;


### PR DESCRIPTION
## Summary
- remove `programName` from `ProgramBrandingContact` schema
- adjust branding contact routes to use the Program table for the name
- update associated unit tests
- rebuild OpenAPI docs

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_686fc4f0ec68832d8ad6e2bbfe4e08ba