### PR TITLE
Add application builder API

### DIFF
--- a/__tests__/applications.test.ts
+++ b/__tests__/applications.test.ts
@@ -1,0 +1,114 @@
+import request from 'supertest';
+jest.mock('../src/prisma');
+import prisma from '../src/prisma';
+import app from '../src/index';
+import { sign } from '../src/jwt';
+
+const mockedPrisma = prisma as any;
+const token = sign({ userId: 1, email: 'admin@example.com' }, 'development-secret');
+
+beforeEach(() => {
+  mockedPrisma.program.findUnique.mockReset();
+  mockedPrisma.programAssignment.findFirst.mockReset();
+  mockedPrisma.application.create.mockReset();
+  mockedPrisma.application.findFirst.mockReset();
+  mockedPrisma.application.deleteMany.mockReset();
+  mockedPrisma.applicationQuestion.create.mockReset();
+  mockedPrisma.applicationQuestion.findMany.mockReset();
+  mockedPrisma.applicationQuestion.deleteMany.mockReset();
+  mockedPrisma.applicationQuestionOption.create.mockReset();
+  mockedPrisma.applicationQuestionOption.deleteMany.mockReset();
+});
+
+describe('GET /api/programs/:id/application', () => {
+  it('is public and returns config', async () => {
+    mockedPrisma.program.findUnique.mockResolvedValueOnce({ id: 'abc' });
+    mockedPrisma.application.findFirst.mockResolvedValueOnce({ id: 'app1', programId: 'abc', title: 'App', description: '' });
+    mockedPrisma.applicationQuestion.findMany.mockResolvedValueOnce([]);
+    const res = await request(app).get('/api/programs/abc/application');
+    expect(res.status).toBe(200);
+    expect(mockedPrisma.application.findFirst).toHaveBeenCalled();
+  });
+
+  it('returns 404 when missing', async () => {
+    mockedPrisma.program.findUnique.mockResolvedValueOnce(null);
+    const res = await request(app).get('/api/programs/abc/application');
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 when no application', async () => {
+    mockedPrisma.program.findUnique.mockResolvedValueOnce({ id: 'abc' });
+    mockedPrisma.application.findFirst.mockResolvedValueOnce(null);
+    const res = await request(app).get('/api/programs/abc/application');
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('POST /api/programs/:id/application', () => {
+  it('creates when admin', async () => {
+    mockedPrisma.program.findUnique.mockResolvedValueOnce({ id: 'abc' });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'admin' });
+    mockedPrisma.application.create.mockResolvedValueOnce({ id: 'app1' });
+    mockedPrisma.applicationQuestion.create.mockResolvedValue({ id: 1 });
+    const res = await request(app)
+      .post('/api/programs/abc/application')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ title: 'App', questions: [] });
+    expect(res.status).toBe(201);
+    expect(mockedPrisma.application.create).toHaveBeenCalled();
+  });
+
+  it('forbids non admin', async () => {
+    mockedPrisma.program.findUnique.mockResolvedValueOnce({ id: 'abc' });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce(null);
+    const res = await request(app)
+      .post('/api/programs/abc/application')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ title: 'App' });
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 400 when title missing', async () => {
+    mockedPrisma.program.findUnique.mockResolvedValueOnce({ id: 'abc' });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'admin' });
+    const res = await request(app)
+      .post('/api/programs/abc/application')
+      .set('Authorization', `Bearer ${token}`)
+      .send({});
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 for invalid program', async () => {
+    mockedPrisma.program.findUnique.mockResolvedValueOnce(null);
+    const res = await request(app)
+      .post('/api/programs/abc/application')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ title: 'App' });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('DELETE /api/programs/:id/application', () => {
+  it('deletes when admin', async () => {
+    mockedPrisma.program.findUnique.mockResolvedValueOnce({ id: 'abc' });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'admin' });
+    mockedPrisma.application.deleteMany.mockResolvedValueOnce({});
+    mockedPrisma.applicationQuestion.deleteMany.mockResolvedValueOnce({});
+    mockedPrisma.applicationQuestionOption.deleteMany.mockResolvedValueOnce({});
+    const res = await request(app)
+      .delete('/api/programs/abc/application')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(mockedPrisma.application.deleteMany).toHaveBeenCalled();
+  });
+
+  it('forbids delete when not admin', async () => {
+    mockedPrisma.program.findUnique.mockResolvedValueOnce({ id: 'abc' });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce(null);
+    const res = await request(app)
+      .delete('/api/programs/abc/application')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(403);
+  });
+});
+

--- a/dist/app.js
+++ b/dist/app.js
@@ -59,6 +59,7 @@ const staff_1 = __importDefault(require("./routes/staff"));
 const parents_1 = __importDefault(require("./routes/parents"));
 const elections_1 = __importDefault(require("./routes/elections"));
 const brandingContact_1 = __importDefault(require("./routes/brandingContact"));
+const applications_1 = __importDefault(require("./routes/applications"));
 const app = (0, express_1.default)();
 exports.default = app;
 const corsOptions = { origin: true, credentials: true };
@@ -73,7 +74,8 @@ const jwtSecret = process.env.JWT_SECRET || 'development-secret';
 app.use((req, res, next) => {
     if (req.path === '/login' ||
         req.path === '/register' ||
-        req.path.startsWith('/docs')) {
+        req.path.startsWith('/docs') ||
+        (req.method === 'GET' && /^\/api\/programs\/[^/]+\/application$/.test(req.path))) {
         return next();
     }
     const auth = req.headers.authorization;
@@ -113,6 +115,7 @@ app.use(staff_1.default);
 app.use(parents_1.default);
 app.use(elections_1.default);
 app.use(brandingContact_1.default);
+app.use(applications_1.default);
 const port = process.env.PORT || 3000;
 if (process.env.NODE_ENV !== 'test') {
     ensureDatabase();

--- a/dist/openapi.yaml
+++ b/dist/openapi.yaml
@@ -35,6 +35,8 @@ tags:
     description: Manage program positions
   - name: brandingContact
     description: Manage branding and contact details
+  - name: applications
+    description: Manage program application forms
 paths:
   /health:
     get:
@@ -950,6 +952,127 @@ paths:
                 contactPhone: "123-456-7890"
                 contactWebsite: https://txboysstate.org
                 contactFacebook: https://facebook.com/txboysstate
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              example: {}
+        "404":
+          description: Not found
+          content:
+            application/json:
+              example: {}
+      security:
+        - bearerAuth: []
+  /api/programs/{programId}/application:
+    get:
+      tags:
+        - applications
+      summary: Get application configuration
+      parameters:
+        - in: path
+          name: programId
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Application configuration
+          content:
+            application/json:
+              schema:
+                type: object
+        "404":
+          description: Not found
+          content:
+            application/json:
+              example: {}
+    post:
+      tags:
+        - applications
+      summary: Create application configuration
+      parameters:
+        - in: path
+          name: programId
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        "201":
+          description: Created configuration
+          content:
+            application/json:
+              schema:
+                type: object
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              example: {}
+        "404":
+          description: Not found
+          content:
+            application/json:
+              example: {}
+      security:
+        - bearerAuth: []
+    put:
+      tags:
+        - applications
+      summary: Update application configuration
+      parameters:
+        - in: path
+          name: programId
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        "201":
+          description: Created configuration
+          content:
+            application/json:
+              schema:
+                type: object
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              example: {}
+        "404":
+          description: Not found
+          content:
+            application/json:
+              example: {}
+      security:
+        - bearerAuth: []
+    delete:
+      tags:
+        - applications
+      summary: Delete application configuration
+      parameters:
+        - in: path
+          name: programId
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Deleted
+          content:
+            application/json:
+              example: {}
         "403":
           description: Forbidden
           content:

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -35,6 +35,7 @@ model Program {
   parties       Party[]
   positions     Position[]
   brandingContacts ProgramBrandingContact[]
+  applications     Application[]
   status        String              @default("active")
   createdAt     DateTime            @default(now())
 }
@@ -387,4 +388,48 @@ model ProgramBrandingContactAudit {
   changedAt         DateTime @default(now())
 
   @@index([brandingContactId])
+}
+
+model Application {
+  id          String                @id @default(cuid())
+  program     Program               @relation(fields: [programId], references: [id])
+  programId   String
+  title       String
+  description String?
+  createdAt   DateTime              @default(now())
+  updatedAt   DateTime              @updatedAt
+
+  questions   ApplicationQuestion[]
+
+  @@index([programId])
+}
+
+model ApplicationQuestion {
+  id            Int                     @id @default(autoincrement())
+  application   Application             @relation(fields: [applicationId], references: [id])
+  applicationId String
+  parent        ApplicationQuestion?    @relation("QuestionChildren", fields: [parentId], references: [id])
+  parentId      Int?
+  children      ApplicationQuestion[]   @relation("QuestionChildren")
+  order         Int
+  type          String
+  text          String
+  required      Boolean?
+  accept        String?
+  maxFiles      Int?
+
+  options       ApplicationQuestionOption[]
+
+  @@index([applicationId])
+  @@index([parentId])
+}
+
+model ApplicationQuestionOption {
+  id         Int                 @id @default(autoincrement())
+  question   ApplicationQuestion @relation(fields: [questionId], references: [id])
+  questionId Int
+  value      String
+  order      Int
+
+  @@index([questionId])
 }

--- a/src/__mocks__/prisma.ts
+++ b/src/__mocks__/prisma.ts
@@ -93,6 +93,21 @@ const prisma = {
     create: jest.fn(),
     groupBy: jest.fn(),
   },
+  application: {
+    create: jest.fn(),
+    findFirst: jest.fn(),
+    deleteMany: jest.fn(),
+  },
+  applicationQuestion: {
+    create: jest.fn(),
+    findMany: jest.fn(),
+    deleteMany: jest.fn(),
+  },
+  applicationQuestionOption: {
+    create: jest.fn(),
+    findMany: jest.fn(),
+    deleteMany: jest.fn(),
+  },
   log: {
     create: jest.fn().mockResolvedValue(null),
     findMany: jest.fn(),

--- a/src/app.ts
+++ b/src/app.ts
@@ -17,6 +17,7 @@ import staffRoutes from './routes/staff';
 import parentsRoutes from './routes/parents';
 import electionsRoutes from './routes/elections';
 import brandingContactRoutes from './routes/brandingContact';
+import applicationsRoutes from './routes/applications';
 
 const app = express();
 const corsOptions: CorsOptions = { origin: true, credentials: true };
@@ -35,7 +36,8 @@ app.use((req, res, next) => {
   if (
     req.path === '/login' ||
     req.path === '/register' ||
-    req.path.startsWith('/docs')
+    req.path.startsWith('/docs') ||
+    (req.method === 'GET' && /^\/api\/programs\/[^/]+\/application$/.test(req.path))
   ) {
     return next();
   }
@@ -76,6 +78,7 @@ app.use(staffRoutes);
 app.use(parentsRoutes);
 app.use(electionsRoutes);
 app.use(brandingContactRoutes);
+app.use(applicationsRoutes);
 
 const port = process.env.PORT || 3000;
 if (process.env.NODE_ENV !== 'test') {

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -35,6 +35,8 @@ tags:
     description: Manage program positions
   - name: brandingContact
     description: Manage branding and contact details
+  - name: applications
+    description: Manage program application forms
 paths:
   /health:
     get:
@@ -950,6 +952,127 @@ paths:
                 contactPhone: "123-456-7890"
                 contactWebsite: https://txboysstate.org
                 contactFacebook: https://facebook.com/txboysstate
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              example: {}
+        "404":
+          description: Not found
+          content:
+            application/json:
+              example: {}
+      security:
+        - bearerAuth: []
+  /api/programs/{programId}/application:
+    get:
+      tags:
+        - applications
+      summary: Get application configuration
+      parameters:
+        - in: path
+          name: programId
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Application configuration
+          content:
+            application/json:
+              schema:
+                type: object
+        "404":
+          description: Not found
+          content:
+            application/json:
+              example: {}
+    post:
+      tags:
+        - applications
+      summary: Create application configuration
+      parameters:
+        - in: path
+          name: programId
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        "201":
+          description: Created configuration
+          content:
+            application/json:
+              schema:
+                type: object
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              example: {}
+        "404":
+          description: Not found
+          content:
+            application/json:
+              example: {}
+      security:
+        - bearerAuth: []
+    put:
+      tags:
+        - applications
+      summary: Update application configuration
+      parameters:
+        - in: path
+          name: programId
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        "201":
+          description: Created configuration
+          content:
+            application/json:
+              schema:
+                type: object
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              example: {}
+        "404":
+          description: Not found
+          content:
+            application/json:
+              example: {}
+      security:
+        - bearerAuth: []
+    delete:
+      tags:
+        - applications
+      summary: Delete application configuration
+      parameters:
+        - in: path
+          name: programId
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Deleted
+          content:
+            application/json:
+              example: {}
         "403":
           description: Forbidden
           content:

--- a/src/routes/applications.ts
+++ b/src/routes/applications.ts
@@ -1,0 +1,126 @@
+import express from 'express';
+import prisma from '../prisma';
+import * as logger from '../logger';
+import { isProgramAdmin } from '../utils/auth';
+
+const router = express.Router();
+
+function buildTree(questions: any[]) {
+  const byId: Record<number, any> = {};
+  questions.forEach((q) => {
+    byId[q.id] = { ...q, options: q.options.map((o: any) => o.value), fields: [] };
+  });
+  const roots: any[] = [];
+  questions.forEach((q) => {
+    if (q.parentId) {
+      byId[q.parentId].fields.push(byId[q.id]);
+    } else {
+      roots.push(byId[q.id]);
+    }
+  });
+  return roots.sort((a, b) => a.order - b.order);
+}
+
+async function saveQuestions(applicationId: string, items: any[], parentId?: number) {
+  for (let i = 0; i < items.length; i++) {
+    const q = items[i];
+    const created = await prisma.applicationQuestion.create({
+      data: {
+        applicationId,
+        parentId: parentId ?? null,
+        order: i,
+        type: q.type,
+        text: q.text,
+        required: q.required ?? null,
+        accept: q.accept,
+        maxFiles: q.maxFiles,
+      },
+    });
+    if (Array.isArray(q.options)) {
+      for (let j = 0; j < q.options.length; j++) {
+        await prisma.applicationQuestionOption.create({
+          data: { questionId: created.id, value: q.options[j], order: j },
+        });
+      }
+    }
+    if (Array.isArray(q.fields)) {
+      await saveQuestions(applicationId, q.fields, created.id);
+    }
+  }
+}
+
+router.get('/api/programs/:programId/application', async (req, res) => {
+  const { programId } = req.params as { programId: string };
+  const program = await prisma.program.findUnique({ where: { id: programId } });
+  if (!program) {
+    res.status(404).json({ error: 'Not found' });
+    return;
+  }
+  const application = await prisma.application.findFirst({ where: { programId } });
+  if (!application) {
+    res.status(404).json({ error: 'Not found' });
+    return;
+  }
+  const questions = await prisma.applicationQuestion.findMany({
+    where: { applicationId: application.id },
+    orderBy: { order: 'asc' },
+    include: { options: { orderBy: { order: 'asc' } } },
+  });
+  const result = buildTree(questions);
+  res.json({ applicationId: application.id, title: application.title, description: application.description, questions: result });
+});
+
+async function saveApplication(req: express.Request, res: express.Response) {
+  const { programId } = req.params as { programId: string };
+  const caller = (req as any).user as { userId: number; email: string };
+  if (!programId) {
+    res.status(400).json({ error: 'programId required' });
+    return;
+  }
+  const program = await prisma.program.findUnique({ where: { id: programId } });
+  if (!program) {
+    res.status(404).json({ error: 'Not found' });
+    return;
+  }
+  const isAdmin = await isProgramAdmin(caller.userId, programId);
+  if (!isAdmin) {
+    res.status(403).json({ error: 'Forbidden' });
+    return;
+  }
+  const { title, description, questions } = req.body as any;
+  if (!title) {
+    res.status(400).json({ error: 'title required' });
+    return;
+  }
+  await prisma.application.deleteMany({ where: { programId } });
+  const application = await prisma.application.create({ data: { programId, title, description } });
+  await saveQuestions(application.id, questions || []);
+  logger.info(programId, `Application saved by ${caller.email}`);
+  res.status(201).json({ applicationId: application.id, title, description, questions });
+}
+
+router.post('/api/programs/:programId/application', saveApplication);
+router.put('/api/programs/:programId/application', saveApplication);
+
+router.delete('/api/programs/:programId/application', async (req, res) => {
+  const { programId } = req.params as { programId: string };
+  const caller = (req as any).user as { userId: number; email: string };
+  const program = await prisma.program.findUnique({ where: { id: programId } });
+  if (!program) {
+    res.status(404).json({ error: 'Not found' });
+    return;
+  }
+  const isAdmin = await isProgramAdmin(caller.userId, programId);
+  if (!isAdmin) {
+    res.status(403).json({ error: 'Forbidden' });
+    return;
+  }
+  await prisma.application.deleteMany({ where: { programId } });
+  await prisma.applicationQuestion.deleteMany({ where: { application: { programId } } });
+  await prisma.applicationQuestionOption.deleteMany({ where: { question: { application: { programId } } } });
+  logger.info(programId, `Application deleted by ${caller.email}`);
+  res.json({ status: 'deleted' });
+});
+
+export default router;
+


### PR DESCRIPTION
## Summary
- implement application builder endpoints with GET/POST/PUT/DELETE
- add Prisma models for applications and related questions
- update mocks and tests
- document new endpoints in OpenAPI
- allow public access to the application GET endpoint

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687653789974832db39e7550ed8944bd