### PR TITLE
Improve applications route coverage

### DIFF
--- a/__tests__/applications.test.ts
+++ b/__tests__/applications.test.ts
@@ -112,3 +112,79 @@ describe('DELETE /api/programs/:id/application', () => {
   });
 });
 
+describe('additional coverage for application routes', () => {
+  it('builds nested question tree on GET', async () => {
+    mockedPrisma.program.findUnique.mockResolvedValueOnce({ id: 'abc' });
+    mockedPrisma.application.findFirst.mockResolvedValueOnce({
+      id: 'app1',
+      programId: 'abc',
+      title: 'App',
+      description: 'desc',
+    });
+    mockedPrisma.applicationQuestion.findMany.mockResolvedValueOnce([
+      {
+        id: 10,
+        parentId: null,
+        order: 0,
+        type: 'text',
+        text: 'q1',
+        options: [{ value: 'a', order: 0 }],
+      },
+      {
+        id: 11,
+        parentId: 10,
+        order: 0,
+        type: 'text',
+        text: 'child',
+        options: [],
+      },
+    ]);
+
+    const res = await request(app).get('/api/programs/abc/application');
+    expect(res.status).toBe(200);
+    expect(res.body.questions[0].fields[0].id).toBe(11);
+    expect(res.body.questions[0].options).toEqual(['a']);
+  });
+
+  it('creates nested questions with options', async () => {
+    mockedPrisma.program.findUnique.mockResolvedValueOnce({ id: 'abc' });
+    mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({ role: 'admin' });
+    mockedPrisma.application.create.mockResolvedValueOnce({ id: 'app1' });
+    mockedPrisma.applicationQuestion.create
+      .mockResolvedValueOnce({ id: 100 })
+      .mockResolvedValueOnce({ id: 200 });
+    mockedPrisma.applicationQuestionOption.create.mockResolvedValue({});
+
+    const res = await request(app)
+      .post('/api/programs/abc/application')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        title: 'App',
+        questions: [
+          {
+            type: 'radio',
+            text: 'q1',
+            options: ['a', 'b'],
+            fields: [{ type: 'text', text: 'child' }],
+          },
+        ],
+      });
+
+    expect(res.status).toBe(201);
+    expect(mockedPrisma.applicationQuestion.create).toHaveBeenCalledTimes(2);
+    expect(mockedPrisma.applicationQuestionOption.create).toHaveBeenCalledTimes(2);
+    const firstCall = mockedPrisma.applicationQuestion.create.mock.calls[0][0];
+    const secondCall = mockedPrisma.applicationQuestion.create.mock.calls[1][0];
+    expect(firstCall.data.parentId).toBeNull();
+    expect(secondCall.data.parentId).toBe(100);
+  });
+
+  it('returns 404 on delete when program missing', async () => {
+    mockedPrisma.program.findUnique.mockResolvedValueOnce(null);
+    const res = await request(app)
+      .delete('/api/programs/abc/application')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(404);
+  });
+});
+


### PR DESCRIPTION
## Summary
- expand applications tests to cover nested question handling and delete edge case

## Testing
- `npm test --silent`
- `npm run build --silent`


------
https://chatgpt.com/codex/tasks/task_b_6888c3d968b4832da6bd5e6bec69722c