### PR TITLE
feat: add application response endpoints

### DIFF
--- a/dist/app.js
+++ b/dist/app.js
@@ -75,7 +75,8 @@ app.use((req, res, next) => {
     if (req.path === '/login' ||
         req.path === '/register' ||
         req.path.startsWith('/docs') ||
-        (req.method === 'GET' && /^\/api\/programs\/[^/]+\/application$/.test(req.path))) {
+        (req.method === 'GET' && /^\/api\/programs\/[^/]+\/application$/.test(req.path)) ||
+        (req.method === 'POST' && /^\/api\/programs\/[^/]+\/application\/responses$/.test(req.path))) {
         return next();
     }
     const auth = req.headers.authorization;

--- a/dist/openapi.yaml
+++ b/dist/openapi.yaml
@@ -1121,6 +1121,85 @@ paths:
               example: {}
       security:
         - bearerAuth: []
+  /api/programs/{programId}/application/responses:
+    post:
+      tags:
+        - applications
+      summary: Submit application response
+      parameters:
+        - in: path
+          name: programId
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                answers:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      questionId:
+                        type: integer
+                      value:
+                        type: string
+            example:
+              answers:
+                - questionId: 1
+                  value: John Doe
+      responses:
+        "201":
+          description: Created response
+          content:
+            application/json:
+              example:
+                responseId: resp123
+        "404":
+          description: Not found
+          content:
+            application/json:
+              example: {}
+    get:
+      tags:
+        - applications
+      summary: List application responses
+      parameters:
+        - in: path
+          name: programId
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Responses
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+              example:
+                - id: resp123
+                  answers:
+                    - questionId: 1
+                      value: John Doe
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              example: {}
+        "404":
+          description: Not found
+          content:
+            application/json:
+              example: {}
+      security:
+        - bearerAuth: []
   /programs/{programId}/users:
     post:
       tags:

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -400,6 +400,7 @@ model Application {
   updatedAt   DateTime              @updatedAt
 
   questions   ApplicationQuestion[]
+  responses   ApplicationResponse[]
 
   @@index([programId])
 }
@@ -419,6 +420,7 @@ model ApplicationQuestion {
   maxFiles      Int?
 
   options       ApplicationQuestionOption[]
+  answers       ApplicationAnswer[]
 
   @@index([applicationId])
   @@index([parentId])
@@ -431,5 +433,27 @@ model ApplicationQuestionOption {
   value      String
   order      Int
 
+  @@index([questionId])
+}
+
+model ApplicationResponse {
+  id String @id @default(cuid())
+  application Application @relation(fields: [applicationId], references: [id])
+  applicationId String
+  createdAt DateTime @default(now())
+  answers ApplicationAnswer[]
+
+  @@index([applicationId])
+}
+
+model ApplicationAnswer {
+  id Int @id @default(autoincrement())
+  response ApplicationResponse @relation(fields: [responseId], references: [id])
+  responseId String
+  question ApplicationQuestion @relation(fields: [questionId], references: [id])
+  questionId Int
+  value String
+
+  @@index([responseId])
   @@index([questionId])
 }

--- a/src/__mocks__/prisma.ts
+++ b/src/__mocks__/prisma.ts
@@ -108,6 +108,10 @@ const prisma = {
     findMany: jest.fn(),
     deleteMany: jest.fn(),
   },
+  applicationResponse: {
+    create: jest.fn(),
+    findMany: jest.fn(),
+  },
   log: {
     create: jest.fn().mockResolvedValue(null),
     findMany: jest.fn(),

--- a/src/app.ts
+++ b/src/app.ts
@@ -37,7 +37,8 @@ app.use((req, res, next) => {
     req.path === '/login' ||
     req.path === '/register' ||
     req.path.startsWith('/docs') ||
-    (req.method === 'GET' && /^\/api\/programs\/[^/]+\/application$/.test(req.path))
+    (req.method === 'GET' && /^\/api\/programs\/[^/]+\/application$/.test(req.path)) ||
+    (req.method === 'POST' && /^\/api\/programs\/[^/]+\/application\/responses$/.test(req.path))
   ) {
     return next();
   }

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -1121,6 +1121,85 @@ paths:
               example: {}
       security:
         - bearerAuth: []
+  /api/programs/{programId}/application/responses:
+    post:
+      tags:
+        - applications
+      summary: Submit application response
+      parameters:
+        - in: path
+          name: programId
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                answers:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      questionId:
+                        type: integer
+                      value:
+                        type: string
+            example:
+              answers:
+                - questionId: 1
+                  value: John Doe
+      responses:
+        "201":
+          description: Created response
+          content:
+            application/json:
+              example:
+                responseId: resp123
+        "404":
+          description: Not found
+          content:
+            application/json:
+              example: {}
+    get:
+      tags:
+        - applications
+      summary: List application responses
+      parameters:
+        - in: path
+          name: programId
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Responses
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+              example:
+                - id: resp123
+                  answers:
+                    - questionId: 1
+                      value: John Doe
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              example: {}
+        "404":
+          description: Not found
+          content:
+            application/json:
+              example: {}
+      security:
+        - bearerAuth: []
   /programs/{programId}/users:
     post:
       tags:


### PR DESCRIPTION
## Summary
- store application responses
- submit application answers anonymously
- allow admins to review application responses

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_688e5c054de0832d915da601db9dd15c