### PR TITLE
Allow JSON application answers

### DIFF
--- a/__tests__/applications.test.ts
+++ b/__tests__/applications.test.ts
@@ -318,6 +318,25 @@ describe('POST /api/programs/:id/application/responses', () => {
     expect(res.status).toBe(201);
     expect(mockedPrisma.applicationResponse.create).toHaveBeenCalled();
   });
+
+  it('supports array and object answers', async () => {
+    mockedPrisma.program.findUnique.mockResolvedValueOnce({ id: 'abc' });
+    mockedPrisma.application.findFirst.mockResolvedValueOnce({ id: 'app1' });
+    mockedPrisma.applicationResponse.create.mockResolvedValueOnce({ id: 'resp1' });
+    const res = await request(app)
+      .post('/api/programs/abc/application/responses')
+      .send({
+        answers: [
+          { questionId: 1, value: ['a', 'b'] },
+          { questionId: 2, value: { start: '2025-01-01', end: '2025-01-02' } },
+        ],
+      });
+    expect(res.status).toBe(201);
+    expect(mockedPrisma.applicationResponse.create).toHaveBeenCalled();
+    const args = mockedPrisma.applicationResponse.create.mock.calls[0][0];
+    expect(args.data.answers.create[0].value).toEqual(['a', 'b']);
+    expect(args.data.answers.create[1].value).toEqual({ start: '2025-01-01', end: '2025-01-02' });
+  });
 });
 
 describe('GET /api/programs/:id/application/responses', () => {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -452,7 +452,7 @@ model ApplicationAnswer {
   responseId String
   question ApplicationQuestion @relation(fields: [questionId], references: [id])
   questionId Int
-  value String
+  value Json
 
   @@index([responseId])
   @@index([questionId])


### PR DESCRIPTION
## Summary
- store application answer values as JSON to support arrays and objects
- accept and normalize JSON values when creating responses
- test application submissions with array and object answers

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_688e9936dff8832db1febfdad3b2d1a0