### PR TITLE
Return 204 instead of 404 when records not found

### DIFF
--- a/__tests__/applications.test.ts
+++ b/__tests__/applications.test.ts
@@ -32,17 +32,17 @@ describe('GET /api/programs/:id/application', () => {
     expect(mockedPrisma.application.findFirst).toHaveBeenCalled();
   });
 
-  it('returns 404 when missing', async () => {
+  it('returns 204 when missing', async () => {
     mockedPrisma.program.findUnique.mockResolvedValueOnce(null);
     const res = await request(app).get('/api/programs/abc/application');
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(204);
   });
 
-  it('returns 404 when no application', async () => {
+  it('returns 204 when no application', async () => {
     mockedPrisma.program.findUnique.mockResolvedValueOnce({ id: 'abc' });
     mockedPrisma.application.findFirst.mockResolvedValueOnce(null);
     const res = await request(app).get('/api/programs/abc/application');
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(204);
   });
 });
 
@@ -80,13 +80,13 @@ describe('POST /api/programs/:id/application', () => {
     expect(res.status).toBe(400);
   });
 
-  it('returns 404 for invalid program', async () => {
+  it('returns 204 for invalid program', async () => {
     mockedPrisma.program.findUnique.mockResolvedValueOnce(null);
     const res = await request(app)
       .post('/api/programs/abc/application')
       .set('Authorization', `Bearer ${token}`)
       .send({ title: 'App' });
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(204);
   });
 });
 
@@ -298,12 +298,12 @@ describe('additional coverage for application routes', () => {
     expect(getRes.body.questions[2].options).toEqual(['a', 'b']);
   });
 
-  it('returns 404 on delete when program missing', async () => {
+  it('returns 204 on delete when program missing', async () => {
     mockedPrisma.program.findUnique.mockResolvedValueOnce(null);
     const res = await request(app)
       .delete('/api/programs/abc/application')
       .set('Authorization', `Bearer ${token}`);
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(204);
   });
 });
 

--- a/__tests__/brandingContact.test.ts
+++ b/__tests__/brandingContact.test.ts
@@ -76,14 +76,14 @@ describe('GET /api/branding-contact/:programId forbidden', () => {
 });
 
 describe('GET /api/branding-contact/:programId not found', () => {
-  it('returns 404 when record missing', async () => {
+  it('returns 204 when record missing', async () => {
     mockedPrisma.program.findUnique.mockResolvedValueOnce({ id: 'abc' });
     mockedPrisma.programAssignment.findFirst.mockResolvedValueOnce({});
     mockedPrisma.programBrandingContact.findFirst.mockResolvedValueOnce(null);
     const res = await request(app)
       .get('/api/branding-contact/abc')
       .set('Authorization', `Bearer ${token}`);
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(204);
   });
 });
 

--- a/__tests__/delegates.error.test.ts
+++ b/__tests__/delegates.error.test.ts
@@ -34,13 +34,13 @@ describe('Delegate error cases', () => {
     expect(res.status).toBe(403);
   });
 
-  it('returns 404 when updating missing delegate', async () => {
+  it('returns 204 when updating missing delegate', async () => {
     mockedPrisma.delegate.findUnique.mockResolvedValueOnce(null);
     const res = await request(app)
       .put('/delegates/1')
       .set('Authorization', `Bearer ${token}`)
       .send({ firstName: 'Jane' });
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(204);
   });
 
   it('rejects update when not admin', async () => {
@@ -54,12 +54,12 @@ describe('Delegate error cases', () => {
     expect(res.status).toBe(403);
   });
 
-  it('returns 404 when deleting missing delegate', async () => {
+  it('returns 204 when deleting missing delegate', async () => {
     mockedPrisma.delegate.findUnique.mockResolvedValueOnce(null);
     const res = await request(app)
       .delete('/delegates/1')
       .set('Authorization', `Bearer ${token}`);
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(204);
   });
 
   it('rejects delete when not admin', async () => {

--- a/__tests__/elections.error.test.ts
+++ b/__tests__/elections.error.test.ts
@@ -27,13 +27,13 @@ describe('Election error cases', () => {
     expect(res.status).toBe(403);
   });
 
-  it('returns 404 when program year missing', async () => {
+  it('returns 204 when program year missing', async () => {
     mockedPrisma.programYear.findUnique.mockResolvedValueOnce(null);
     const res = await request(app)
       .post('/program-years/1/elections')
       .set('Authorization', `Bearer ${token}`)
       .send({ positionId: 1, groupingId: 2, method: 'plurality' });
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(204);
   });
 
   it('requires required fields', async () => {
@@ -55,13 +55,13 @@ describe('Election error cases', () => {
     expect(res.status).toBe(403);
   });
 
-  it('returns 404 when updating missing election', async () => {
+  it('returns 204 when updating missing election', async () => {
     mockedPrisma.election.findUnique.mockResolvedValueOnce(null);
     const res = await request(app)
       .put('/elections/1')
       .set('Authorization', `Bearer ${token}`)
       .send({ status: 'closed' });
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(204);
   });
 
   it('rejects update when not admin', async () => {
@@ -75,12 +75,12 @@ describe('Election error cases', () => {
     expect(res.status).toBe(403);
   });
 
-  it('returns 404 when deleting missing election', async () => {
+  it('returns 204 when deleting missing election', async () => {
     mockedPrisma.election.findUnique.mockResolvedValueOnce(null);
     const res = await request(app)
       .delete('/elections/1')
       .set('Authorization', `Bearer ${token}`);
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(204);
   });
 
   it('rejects delete when not admin', async () => {
@@ -124,38 +124,38 @@ describe('Election error cases', () => {
       .set('Authorization', `Bearer ${token}`);
     expect(res.status).toBe(403);
   });
-it('returns 404 when listing elections and program year missing', async () => {
+it('returns 204 when listing elections and program year missing', async () => {
   mockedPrisma.programYear.findUnique.mockResolvedValueOnce(null);
   const res = await request(app)
     .get('/program-years/1/elections')
     .set('Authorization', `Bearer ${token}`);
-  expect(res.status).toBe(404);
+  expect(res.status).toBe(204);
 });
 
-it('returns 404 when voting and program year missing', async () => {
+it('returns 204 when voting and program year missing', async () => {
   mockedPrisma.election.findUnique.mockResolvedValueOnce({ id: 1, programYearId: 1 });
   mockedPrisma.programYear.findUnique.mockResolvedValueOnce(null);
   const res = await request(app)
     .post('/elections/1/vote')
     .set('Authorization', `Bearer ${token}`)
     .send({ candidateId: 2, voterId: 3 });
-  expect(res.status).toBe(404);
+  expect(res.status).toBe(204);
 });
 
-it('returns 404 when results election missing', async () => {
+it('returns 204 when results election missing', async () => {
   mockedPrisma.election.findUnique.mockResolvedValueOnce(null);
   const res = await request(app)
     .get('/elections/1/results')
     .set('Authorization', `Bearer ${token}`);
-  expect(res.status).toBe(404);
+  expect(res.status).toBe(204);
 });
 
-it('returns 404 when results program year missing', async () => {
+it('returns 204 when results program year missing', async () => {
   mockedPrisma.election.findUnique.mockResolvedValueOnce({ id: 1, programYearId: 1 });
   mockedPrisma.programYear.findUnique.mockResolvedValueOnce(null);
   const res = await request(app)
     .get('/elections/1/results')
     .set('Authorization', `Bearer ${token}`);
-  expect(res.status).toBe(404);
+  expect(res.status).toBe(204);
 });
 });

--- a/__tests__/groupingTypes.error.test.ts
+++ b/__tests__/groupingTypes.error.test.ts
@@ -41,12 +41,12 @@ describe('GroupingType error cases', () => {
     expect(res.status).toBe(403);
   });
 
-  it('returns 404 when deleting missing type', async () => {
+  it('returns 204 when deleting missing type', async () => {
     mockedPrisma.groupingType.findUnique.mockResolvedValueOnce(null);
     const res = await request(app)
       .delete('/grouping-types/1')
       .set('Authorization', `Bearer ${token}`);
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(204);
   });
 
   it('rejects delete when not admin', async () => {

--- a/__tests__/groupingTypes.test.ts
+++ b/__tests__/groupingTypes.test.ts
@@ -58,13 +58,13 @@ describe('GroupingType endpoints', () => {
     expect(mockedPrisma.groupingType.update).toHaveBeenCalled();
   });
 
-  it('returns 404 when grouping type not found', async () => {
+  it('returns 204 when grouping type not found', async () => {
     mockedPrisma.groupingType.findUnique.mockResolvedValueOnce(null);
     const res = await request(app)
       .put('/grouping-types/99')
       .set('Authorization', `Bearer ${token}`)
       .send({ customName: 'Town' });
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(204);
   });
 
   it('retires grouping type', async () => {

--- a/__tests__/groupings.error.test.ts
+++ b/__tests__/groupings.error.test.ts
@@ -33,13 +33,13 @@ describe('Grouping error cases', () => {
     expect(res.status).toBe(403);
   });
 
-  it('returns 404 when updating missing grouping', async () => {
+  it('returns 204 when updating missing grouping', async () => {
     mockedPrisma.grouping.findUnique.mockResolvedValueOnce(null);
     const res = await request(app)
       .put('/groupings/1')
       .set('Authorization', `Bearer ${token}`)
       .send({ name: 'Updated' });
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(204);
   });
 
   it('rejects update when not admin', async () => {
@@ -52,12 +52,12 @@ describe('Grouping error cases', () => {
     expect(res.status).toBe(403);
   });
 
-  it('returns 404 when deleting missing grouping', async () => {
+  it('returns 204 when deleting missing grouping', async () => {
     mockedPrisma.grouping.findUnique.mockResolvedValueOnce(null);
     const res = await request(app)
       .delete('/groupings/1')
       .set('Authorization', `Bearer ${token}`);
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(204);
   });
 
   it('rejects delete when not admin', async () => {

--- a/__tests__/parents.error.test.ts
+++ b/__tests__/parents.error.test.ts
@@ -36,13 +36,13 @@ describe('Parent error cases', () => {
     expect(res.status).toBe(403);
   });
 
-  it('returns 404 when updating missing parent', async () => {
+  it('returns 204 when updating missing parent', async () => {
     mockedPrisma.parent.findUnique.mockResolvedValueOnce(null);
     const res = await request(app)
       .put('/parents/1')
       .set('Authorization', `Bearer ${token}`)
       .send({ firstName: 'Janet' });
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(204);
   });
 
   it('rejects update when not admin', async () => {
@@ -56,12 +56,12 @@ describe('Parent error cases', () => {
     expect(res.status).toBe(403);
   });
 
-  it('returns 404 when removing missing parent', async () => {
+  it('returns 204 when removing missing parent', async () => {
     mockedPrisma.parent.findUnique.mockResolvedValueOnce(null);
     const res = await request(app)
       .delete('/parents/1')
       .set('Authorization', `Bearer ${token}`);
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(204);
   });
 
   it('rejects remove when not admin', async () => {
@@ -94,48 +94,48 @@ describe('Parent error cases', () => {
       .send({ status: 'accepted' });
     expect(res.status).toBe(403);
   });
-it('returns 404 when listing parents and program year missing', async () => {
+it('returns 204 when listing parents and program year missing', async () => {
   mockedPrisma.programYear.findUnique.mockResolvedValueOnce(null);
   const res = await request(app)
     .get('/program-years/1/parents')
     .set('Authorization', `Bearer ${token}`);
-  expect(res.status).toBe(404);
+  expect(res.status).toBe(204);
 });
 
-it('returns 404 when removing parent program year missing', async () => {
+it('returns 204 when removing parent program year missing', async () => {
   mockedPrisma.parent.findUnique.mockResolvedValueOnce({ id: 1, programYearId: 1 });
   mockedPrisma.programYear.findUnique.mockResolvedValueOnce(null);
   const res = await request(app)
     .delete('/parents/1')
     .set('Authorization', `Bearer ${token}`);
-  expect(res.status).toBe(404);
+  expect(res.status).toBe(204);
 });
 
-it('returns 404 when creating link with unknown program year', async () => {
+it('returns 204 when creating link with unknown program year', async () => {
   mockedPrisma.programYear.findUnique.mockResolvedValueOnce(null);
   const res = await request(app)
     .post('/delegate-parent-links')
     .set('Authorization', `Bearer ${token}`)
     .send({ delegateId: 2, parentId: 3, programYearId: 1 });
-  expect(res.status).toBe(404);
+  expect(res.status).toBe(204);
 });
 
-it('returns 404 when link to update not found', async () => {
+it('returns 204 when link to update not found', async () => {
   mockedPrisma.delegateParentLink.findUnique.mockResolvedValueOnce(null);
   const res = await request(app)
     .put('/delegate-parent-links/1')
     .set('Authorization', `Bearer ${token}`)
     .send({ status: 'accepted' });
-  expect(res.status).toBe(404);
+  expect(res.status).toBe(204);
 });
 
-it('returns 404 when link update program year missing', async () => {
+it('returns 204 when link update program year missing', async () => {
   mockedPrisma.delegateParentLink.findUnique.mockResolvedValueOnce({ id: 1, programYearId: 1 });
   mockedPrisma.programYear.findUnique.mockResolvedValueOnce(null);
   const res = await request(app)
     .put('/delegate-parent-links/1')
     .set('Authorization', `Bearer ${token}`)
     .send({ status: 'accepted' });
-  expect(res.status).toBe(404);
+  expect(res.status).toBe(204);
 });
 });

--- a/__tests__/parties.error.test.ts
+++ b/__tests__/parties.error.test.ts
@@ -40,13 +40,13 @@ describe('Party error cases', () => {
     expect(res.status).toBe(403);
   });
 
-  it('returns 404 when updating missing party', async () => {
+  it('returns 204 when updating missing party', async () => {
     mockedPrisma.party.findUnique.mockResolvedValueOnce(null);
     const res = await request(app)
       .put('/parties/1')
       .set('Authorization', `Bearer ${token}`)
       .send({ name: 'B' });
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(204);
   });
 
   it('rejects update when not admin', async () => {
@@ -59,12 +59,12 @@ describe('Party error cases', () => {
     expect(res.status).toBe(403);
   });
 
-  it('returns 404 when deleting missing party', async () => {
+  it('returns 204 when deleting missing party', async () => {
     mockedPrisma.party.findUnique.mockResolvedValueOnce(null);
     const res = await request(app)
       .delete('/parties/1')
       .set('Authorization', `Bearer ${token}`);
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(204);
   });
 
   it('rejects delete when not admin', async () => {

--- a/__tests__/positions.error.test.ts
+++ b/__tests__/positions.error.test.ts
@@ -41,13 +41,13 @@ describe('Position error cases', () => {
     expect(res.status).toBe(403);
   });
 
-  it('returns 404 when updating missing position', async () => {
+  it('returns 204 when updating missing position', async () => {
     mockedPrisma.position.findUnique.mockResolvedValueOnce(null);
     const res = await request(app)
       .put('/positions/1')
       .set('Authorization', `Bearer ${token}`)
       .send({ name: 'New' });
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(204);
   });
 
   it('rejects update when not admin', async () => {
@@ -60,12 +60,12 @@ describe('Position error cases', () => {
     expect(res.status).toBe(403);
   });
 
-  it('returns 404 when deleting missing position', async () => {
+  it('returns 204 when deleting missing position', async () => {
     mockedPrisma.position.findUnique.mockResolvedValueOnce(null);
     const res = await request(app)
       .delete('/positions/1')
       .set('Authorization', `Bearer ${token}`);
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(204);
   });
 
   it('rejects delete when not admin', async () => {

--- a/__tests__/programYearPositions.error.test.ts
+++ b/__tests__/programYearPositions.error.test.ts
@@ -26,13 +26,13 @@ describe('ProgramYearPosition error cases', () => {
     expect(res.status).toBe(403);
   });
 
-  it('returns 404 when program year missing', async () => {
+  it('returns 204 when program year missing', async () => {
     mockedPrisma.programYear.findUnique.mockResolvedValueOnce(null);
     const res = await request(app)
       .post('/program-years/1/positions')
       .set('Authorization', `Bearer ${token}`)
       .send({ positionId: 2 });
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(204);
   });
 
   it('rejects list when not member', async () => {
@@ -44,13 +44,13 @@ describe('ProgramYearPosition error cases', () => {
     expect(res.status).toBe(403);
   });
 
-  it('returns 404 when updating missing record', async () => {
+  it('returns 204 when updating missing record', async () => {
     mockedPrisma.programYearPosition.findUnique.mockResolvedValueOnce(null);
     const res = await request(app)
       .put('/program-year-positions/1')
       .set('Authorization', `Bearer ${token}`)
       .send({ delegateId: 5 });
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(204);
   });
 
   it('rejects update when not admin', async () => {
@@ -64,12 +64,12 @@ describe('ProgramYearPosition error cases', () => {
     expect(res.status).toBe(403);
   });
 
-  it('returns 404 when deleting missing record', async () => {
+  it('returns 204 when deleting missing record', async () => {
     mockedPrisma.programYearPosition.findUnique.mockResolvedValueOnce(null);
     const res = await request(app)
       .delete('/program-year-positions/1')
       .set('Authorization', `Bearer ${token}`);
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(204);
   });
 
   it('rejects delete when not admin', async () => {

--- a/__tests__/programYears.error.test.ts
+++ b/__tests__/programYears.error.test.ts
@@ -41,13 +41,13 @@ describe('ProgramYear error cases', () => {
     expect(res.status).toBe(403);
   });
 
-  it('returns 404 when updating missing year', async () => {
+  it('returns 204 when updating missing year', async () => {
     mockedPrisma.programYear.findUnique.mockResolvedValueOnce(null);
     const res = await request(app)
       .put('/program-years/1')
       .set('Authorization', `Bearer ${token}`)
       .send({ status: 'archived' });
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(204);
   });
 
   it('rejects update when not admin', async () => {
@@ -60,12 +60,12 @@ describe('ProgramYear error cases', () => {
     expect(res.status).toBe(403);
   });
 
-  it('returns 404 when deleting missing year', async () => {
+  it('returns 204 when deleting missing year', async () => {
     mockedPrisma.programYear.findUnique.mockResolvedValueOnce(null);
     const res = await request(app)
       .delete('/program-years/1')
       .set('Authorization', `Bearer ${token}`);
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(204);
   });
 
   it('rejects delete when not admin', async () => {
@@ -76,12 +76,12 @@ describe('ProgramYear error cases', () => {
       .set('Authorization', `Bearer ${token}`);
     expect(res.status).toBe(403);
   });
-it('returns 404 when getting missing program year', async () => {
+it('returns 204 when getting missing program year', async () => {
   mockedPrisma.programYear.findUnique.mockResolvedValueOnce(null);
   const res = await request(app)
     .get('/program-years/1')
     .set('Authorization', `Bearer ${token}`);
-  expect(res.status).toBe(404);
+  expect(res.status).toBe(204);
 });
 
 it('rejects get when not program member', async () => {

--- a/__tests__/programs.error.test.ts
+++ b/__tests__/programs.error.test.ts
@@ -41,13 +41,13 @@ describe('Program error cases', () => {
     expect(res.status).toBe(403);
   });
 
-  it('returns 404 when updating missing program', async () => {
+  it('returns 204 when updating missing program', async () => {
     mockedPrisma.program.findUnique.mockResolvedValueOnce(null);
     const res = await request(app)
       .put('/programs/abc')
       .set('Authorization', `Bearer ${token}`)
       .send({ name: 'New' });
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(204);
   });
 
   it('rejects update when not admin', async () => {
@@ -59,10 +59,10 @@ describe('Program error cases', () => {
       .send({ name: 'New' });
     expect(res.status).toBe(403);
   });
-it('returns 404 when getting missing program', async () => {
+it('returns 204 when getting missing program', async () => {
   mockedPrisma.program.findUnique.mockResolvedValueOnce(null);
   const res = await request(app).get('/programs/p1').set('Authorization', `Bearer ${token}`);
-  expect(res.status).toBe(404);
+  expect(res.status).toBe(204);
 });
 
 it('rejects get program when not member', async () => {
@@ -73,10 +73,10 @@ it('rejects get program when not member', async () => {
 });
 
 
-it('returns 404 when deleting missing program', async () => {
+it('returns 204 when deleting missing program', async () => {
   mockedPrisma.program.findUnique.mockResolvedValueOnce(null);
   const res = await request(app).delete('/programs/p1').set('Authorization', `Bearer ${token}`);
-  expect(res.status).toBe(404);
+  expect(res.status).toBe(204);
 });
 
 it('rejects delete when not admin', async () => {

--- a/__tests__/programs.test.ts
+++ b/__tests__/programs.test.ts
@@ -74,13 +74,13 @@ describe('GET /programs/:username', () => {
     expect(res.body).toEqual({ username: 'jane.doe', programs: [] });
   });
 
-  it('returns 404 when user does not exist', async () => {
+  it('returns 204 when user does not exist', async () => {
     mockedPrisma.user.findUnique.mockResolvedValueOnce(null);
     const token = sign({ userId: 1, email: 'jane.doe' }, 'development-secret');
     const res = await request(app)
       .get('/user-programs/missing')
       .set('Authorization', `Bearer ${token}`);
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(204);
   });
 
   it('returns 400 when username missing', async () => {

--- a/__tests__/staff.error.test.ts
+++ b/__tests__/staff.error.test.ts
@@ -43,13 +43,13 @@ describe('Staff error cases', () => {
     expect(res.status).toBe(403);
   });
 
-  it('returns 404 when updating missing staff', async () => {
+  it('returns 204 when updating missing staff', async () => {
     mockedPrisma.staff.findUnique.mockResolvedValueOnce(null);
     const res = await request(app)
       .put('/staff/1')
       .set('Authorization', `Bearer ${token}`)
       .send({ role: 'counselor' });
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(204);
   });
 
   it('rejects update when not admin', async () => {
@@ -63,12 +63,12 @@ describe('Staff error cases', () => {
     expect(res.status).toBe(403);
   });
 
-  it('returns 404 when deleting missing staff', async () => {
+  it('returns 204 when deleting missing staff', async () => {
     mockedPrisma.staff.findUnique.mockResolvedValueOnce(null);
     const res = await request(app)
       .delete('/staff/1')
       .set('Authorization', `Bearer ${token}`);
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(204);
   });
 
   it('rejects delete when not admin', async () => {

--- a/dist/routes/programYears.js
+++ b/dist/routes/programYears.js
@@ -97,7 +97,7 @@ router.get('/program-years/:id', async (req, res) => {
     const caller = req.user;
     const py = await prisma_1.default.programYear.findUnique({ where: { id: Number(id) } });
     if (!py) {
-        res.status(404).json({ error: 'Not found' });
+        res.status(204).end();
         return;
     }
     const isMember = await (0, auth_1.isProgramMember)(caller.userId, py.programId);
@@ -113,7 +113,7 @@ router.put('/program-years/:id', async (req, res) => {
     const caller = req.user;
     const py = await prisma_1.default.programYear.findUnique({ where: { id: Number(id) } });
     if (!py) {
-        res.status(404).json({ error: 'Not found' });
+        res.status(204).end();
         return;
     }
     const isAdmin = await (0, auth_1.isProgramAdmin)(caller.userId, py.programId);
@@ -140,7 +140,7 @@ router.delete('/program-years/:id', async (req, res) => {
     const caller = req.user;
     const py = await prisma_1.default.programYear.findUnique({ where: { id: Number(id) } });
     if (!py) {
-        res.status(404).json({ error: 'Not found' });
+        res.status(204).end();
         return;
     }
     const isAdmin = await (0, auth_1.isProgramAdmin)(caller.userId, py.programId);

--- a/dist/routes/programs.js
+++ b/dist/routes/programs.js
@@ -130,7 +130,7 @@ router.get('/programs/:id', async (req, res) => {
     const caller = req.user;
     const program = await prisma_1.default.program.findUnique({ where: { id } });
     if (!program) {
-        res.status(404).json({ error: 'Not found' });
+        res.status(204).end();
         return;
     }
     const member = await (0, auth_1.isProgramMember)(caller.userId, id);
@@ -146,7 +146,7 @@ router.put('/programs/:id', async (req, res) => {
     const caller = req.user;
     const program = await prisma_1.default.program.findUnique({ where: { id } });
     if (!program) {
-        res.status(404).json({ error: 'Not found' });
+        res.status(204).end();
         return;
     }
     const isAdmin = await (0, auth_1.isProgramAdmin)(caller.userId, id);
@@ -168,7 +168,7 @@ router.delete('/programs/:id', async (req, res) => {
     const caller = req.user;
     const program = await prisma_1.default.program.findUnique({ where: { id } });
     if (!program) {
-        res.status(404).json({ error: 'Not found' });
+        res.status(204).end();
         return;
     }
     const isAdmin = await (0, auth_1.isProgramAdmin)(caller.userId, id);

--- a/src/routes/applications.ts
+++ b/src/routes/applications.ts
@@ -54,12 +54,12 @@ router.get('/api/programs/:programId/application', async (req, res) => {
   const { programId } = req.params as { programId: string };
   const program = await prisma.program.findUnique({ where: { id: programId } });
   if (!program) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const application = await prisma.application.findFirst({ where: { programId } });
   if (!application) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const questions = await prisma.applicationQuestion.findMany({
@@ -80,7 +80,7 @@ async function saveApplication(req: express.Request, res: express.Response) {
   }
   const program = await prisma.program.findUnique({ where: { id: programId } });
   if (!program) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const isAdmin = await isProgramAdmin(caller.userId, programId);
@@ -114,7 +114,7 @@ router.delete('/api/programs/:programId/application', async (req, res) => {
   const caller = (req as any).user as { userId: number; email: string };
   const program = await prisma.program.findUnique({ where: { id: programId } });
   if (!program) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const isAdmin = await isProgramAdmin(caller.userId, programId);
@@ -137,12 +137,12 @@ router.post('/api/programs/:programId/application/responses', async (req, res) =
   const { programId } = req.params as { programId: string };
   const program = await prisma.program.findUnique({ where: { id: programId } });
   if (!program) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const application = await prisma.application.findFirst({ where: { programId } });
   if (!application) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const body = req.body as {
@@ -178,7 +178,7 @@ router.get('/api/programs/:programId/application/responses', async (req, res) =>
   const caller = (req as any).user as { userId: number; email: string };
   const program = await prisma.program.findUnique({ where: { id: programId } });
   if (!program) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const isAdmin = await isProgramAdmin(caller.userId, programId);

--- a/src/routes/brandingContact.ts
+++ b/src/routes/brandingContact.ts
@@ -21,7 +21,7 @@ async function saveBrandingContact(req: express.Request, res: express.Response) 
   /* istanbul ignore next */
   /* c8 ignore next */
   if (!program) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const admin = await isProgramAdmin(caller.userId, programId);
@@ -113,7 +113,7 @@ router.get('/api/branding-contact/:programId', async (req, res) => {
   const program = await prisma.program.findUnique({ where: { id: programId } });
   /* c8 ignore next */
   if (!program) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const member = await isProgramMember(caller.userId, programId);
@@ -129,7 +129,7 @@ router.get('/api/branding-contact/:programId', async (req, res) => {
   /* istanbul ignore next */
   /* c8 ignore next */
   if (!record) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   res.json({ ...record, programName: program.name });

--- a/src/routes/delegates.ts
+++ b/src/routes/delegates.ts
@@ -10,7 +10,7 @@ router.post('/program-years/:id/delegates', async (req, res) => {
   const caller = (req as any).user as { userId: number };
   const py = await prisma.programYear.findUnique({ where: { id: Number(id) } });
   if (!py) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const isAdmin = await isProgramAdmin(caller.userId, py.programId);
@@ -53,7 +53,7 @@ router.get('/program-years/:id/delegates', async (req, res) => {
   const caller = (req as any).user as { userId: number };
   const py = await prisma.programYear.findUnique({ where: { id: Number(id) } });
   if (!py) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const isMember = await isProgramMember(caller.userId, py.programId);
@@ -70,12 +70,12 @@ router.put('/delegates/:id', async (req, res) => {
   const caller = (req as any).user as { userId: number };
   const delegate = await prisma.delegate.findUnique({ where: { id: Number(id) } });
   if (!delegate) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const py = await prisma.programYear.findUnique({ where: { id: delegate.programYearId } });
   if (!py) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const isAdmin = await isProgramAdmin(caller.userId, py.programId);
@@ -106,12 +106,12 @@ router.delete('/delegates/:id', async (req, res) => {
   const caller = (req as any).user as { userId: number };
   const delegate = await prisma.delegate.findUnique({ where: { id: Number(id) } });
   if (!delegate) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const py = await prisma.programYear.findUnique({ where: { id: delegate.programYearId } });
   if (!py) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const isAdmin = await isProgramAdmin(caller.userId, py.programId);

--- a/src/routes/elections.ts
+++ b/src/routes/elections.ts
@@ -10,7 +10,7 @@ router.post('/program-years/:id/elections', async (req, res) => {
   const caller = (req as any).user as { userId: number };
   const py = await prisma.programYear.findUnique({ where: { id: Number(id) } });
   if (!py) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const isAdmin = await isProgramAdmin(caller.userId, py.programId);
@@ -49,7 +49,7 @@ router.get('/program-years/:id/elections', async (req, res) => {
   const caller = (req as any).user as { userId: number };
   const py = await prisma.programYear.findUnique({ where: { id: Number(id) } });
   if (!py) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const isMember = await isProgramMember(caller.userId, py.programId);
@@ -66,12 +66,12 @@ router.put('/elections/:id', async (req, res) => {
   const caller = (req as any).user as { userId: number };
   const election = await prisma.election.findUnique({ where: { id: Number(id) } });
   if (!election) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const py = await prisma.programYear.findUnique({ where: { id: election.programYearId } });
   if (!py) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const isAdmin = await isProgramAdmin(caller.userId, py.programId);
@@ -101,12 +101,12 @@ router.delete('/elections/:id', async (req, res) => {
   const caller = (req as any).user as { userId: number };
   const election = await prisma.election.findUnique({ where: { id: Number(id) } });
   if (!election) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const py = await prisma.programYear.findUnique({ where: { id: election.programYearId } });
   if (!py) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const isAdmin = await isProgramAdmin(caller.userId, py.programId);
@@ -124,12 +124,12 @@ router.post('/elections/:id/vote', async (req, res) => {
   const caller = (req as any).user as { userId: number };
   const election = await prisma.election.findUnique({ where: { id: Number(id) } });
   if (!election) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const py = await prisma.programYear.findUnique({ where: { id: election.programYearId } });
   if (!py) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const isMember = await isProgramMember(caller.userId, py.programId);
@@ -158,12 +158,12 @@ router.get('/elections/:id/results', async (req, res) => {
   const caller = (req as any).user as { userId: number };
   const election = await prisma.election.findUnique({ where: { id: Number(id) } });
   if (!election) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const py = await prisma.programYear.findUnique({ where: { id: election.programYearId } });
   if (!py) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const isMember = await isProgramMember(caller.userId, py.programId);

--- a/src/routes/groupingTypes.ts
+++ b/src/routes/groupingTypes.ts
@@ -67,7 +67,7 @@ router.put('/grouping-types/:id', async (req, res) => {
   const caller = (req as any).user as { userId: number };
   const gt = await prisma.groupingType.findUnique({ where: { id: Number(id) } });
   if (!gt) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const isAdmin = await isProgramAdmin(caller.userId, gt.programId);
@@ -95,7 +95,7 @@ router.delete('/grouping-types/:id', async (req, res) => {
   const caller = (req as any).user as { userId: number };
   const gt = await prisma.groupingType.findUnique({ where: { id: Number(id) } });
   if (!gt) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const isAdmin = await isProgramAdmin(caller.userId, gt.programId);

--- a/src/routes/groupings.ts
+++ b/src/routes/groupings.ts
@@ -67,7 +67,7 @@ router.put('/groupings/:id', async (req, res) => {
   const caller = (req as any).user as { userId: number };
   const grouping = await prisma.grouping.findUnique({ where: { id: Number(id) } });
   if (!grouping) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const isAdmin = await isProgramAdmin(caller.userId, grouping.programId);
@@ -95,7 +95,7 @@ router.delete('/groupings/:id', async (req, res) => {
   const caller = (req as any).user as { userId: number };
   const grouping = await prisma.grouping.findUnique({ where: { id: Number(id) } });
   if (!grouping) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const isAdmin = await isProgramAdmin(caller.userId, grouping.programId);
@@ -116,7 +116,7 @@ router.post('/program-years/:id/groupings/activate', async (req, res) => {
   const caller = (req as any).user as { userId: number };
   const py = await prisma.programYear.findUnique({ where: { id: Number(id) } });
   if (!py) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const isAdmin = await isProgramAdmin(caller.userId, py.programId);
@@ -145,7 +145,7 @@ router.get('/program-years/:id/groupings', async (req, res) => {
   const caller = (req as any).user as { userId: number };
   const py = await prisma.programYear.findUnique({ where: { id: Number(id) } });
   if (!py) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const isMember = await isProgramMember(caller.userId, py.programId);

--- a/src/routes/parents.ts
+++ b/src/routes/parents.ts
@@ -10,7 +10,7 @@ router.post('/program-years/:id/parents', async (req, res) => {
   const caller = (req as any).user as { userId: number };
   const py = await prisma.programYear.findUnique({ where: { id: Number(id) } });
   if (!py) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const isAdmin = await isProgramAdmin(caller.userId, py.programId);
@@ -49,7 +49,7 @@ router.get('/program-years/:id/parents', async (req, res) => {
   const caller = (req as any).user as { userId: number };
   const py = await prisma.programYear.findUnique({ where: { id: Number(id) } });
   if (!py) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const isMember = await isProgramMember(caller.userId, py.programId);
@@ -66,12 +66,12 @@ router.put('/parents/:id', async (req, res) => {
   const caller = (req as any).user as { userId: number };
   const parent = await prisma.parent.findUnique({ where: { id: Number(id) } });
   if (!parent) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const py = await prisma.programYear.findUnique({ where: { id: parent.programYearId } });
   if (!py) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const isAdmin = await isProgramAdmin(caller.userId, py.programId);
@@ -100,12 +100,12 @@ router.delete('/parents/:id', async (req, res) => {
   const caller = (req as any).user as { userId: number };
   const parent = await prisma.parent.findUnique({ where: { id: Number(id) } });
   if (!parent) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const py = await prisma.programYear.findUnique({ where: { id: parent.programYearId } });
   if (!py) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const isAdmin = await isProgramAdmin(caller.userId, py.programId);
@@ -131,7 +131,7 @@ router.post('/delegate-parent-links', async (req, res) => {
   }
   const py = await prisma.programYear.findUnique({ where: { id: programYearId } });
   if (!py) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const isAdmin = await isProgramAdmin(caller.userId, py.programId);
@@ -151,12 +151,12 @@ router.put('/delegate-parent-links/:id', async (req, res) => {
   const caller = (req as any).user as { userId: number };
   const link = await prisma.delegateParentLink.findUnique({ where: { id: Number(id) } });
   if (!link) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const py = await prisma.programYear.findUnique({ where: { id: link.programYearId } });
   if (!py) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const isAdmin = await isProgramAdmin(caller.userId, py.programId);

--- a/src/routes/parties.ts
+++ b/src/routes/parties.ts
@@ -59,7 +59,7 @@ router.put('/parties/:id', async (req, res) => {
   const caller = (req as any).user as { userId: number };
   const party = await prisma.party.findUnique({ where: { id: Number(id) } });
   if (!party) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const isAdmin = await isProgramAdmin(caller.userId, party.programId);
@@ -88,7 +88,7 @@ router.delete('/parties/:id', async (req, res) => {
   const caller = (req as any).user as { userId: number };
   const party = await prisma.party.findUnique({ where: { id: Number(id) } });
   if (!party) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const isAdmin = await isProgramAdmin(caller.userId, party.programId);
@@ -109,7 +109,7 @@ router.post('/program-years/:id/parties/activate', async (req, res) => {
   const caller = (req as any).user as { userId: number };
   const py = await prisma.programYear.findUnique({ where: { id: Number(id) } });
   if (!py) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const isAdmin = await isProgramAdmin(caller.userId, py.programId);
@@ -138,7 +138,7 @@ router.get('/program-years/:id/parties', async (req, res) => {
   const caller = (req as any).user as { userId: number };
   const py = await prisma.programYear.findUnique({ where: { id: Number(id) } });
   if (!py) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const isMember = await isProgramMember(caller.userId, py.programId);

--- a/src/routes/positions.ts
+++ b/src/routes/positions.ts
@@ -57,7 +57,7 @@ router.put('/positions/:id', async (req, res) => {
   const caller = (req as any).user as { userId: number };
   const position = await prisma.position.findUnique({ where: { id: Number(id) } });
   if (!position) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const isAdmin = await isProgramAdmin(caller.userId, position.programId);
@@ -84,7 +84,7 @@ router.delete('/positions/:id', async (req, res) => {
   const caller = (req as any).user as { userId: number };
   const position = await prisma.position.findUnique({ where: { id: Number(id) } });
   if (!position) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const isAdmin = await isProgramAdmin(caller.userId, position.programId);

--- a/src/routes/programYearPositions.ts
+++ b/src/routes/programYearPositions.ts
@@ -10,7 +10,7 @@ router.post('/program-years/:id/positions', async (req, res) => {
   const caller = (req as any).user as { userId: number };
   const py = await prisma.programYear.findUnique({ where: { id: Number(id) } });
   if (!py) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const isAdmin = await isProgramAdmin(caller.userId, py.programId);
@@ -35,7 +35,7 @@ router.get('/program-years/:id/positions', async (req, res) => {
   const caller = (req as any).user as { userId: number };
   const py = await prisma.programYear.findUnique({ where: { id: Number(id) } });
   if (!py) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const isMember = await isProgramMember(caller.userId, py.programId);
@@ -55,12 +55,12 @@ router.put('/program-year-positions/:id', async (req, res) => {
   const caller = (req as any).user as { userId: number };
   const record = await prisma.programYearPosition.findUnique({ where: { id: Number(id) } });
   if (!record) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const py = await prisma.programYear.findUnique({ where: { id: record.programYearId } });
   if (!py) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const isAdmin = await isProgramAdmin(caller.userId, py.programId);
@@ -79,12 +79,12 @@ router.delete('/program-year-positions/:id', async (req, res) => {
   const caller = (req as any).user as { userId: number };
   const record = await prisma.programYearPosition.findUnique({ where: { id: Number(id) } });
   if (!record) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const py = await prisma.programYear.findUnique({ where: { id: record.programYearId } });
   if (!py) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const isAdmin = await isProgramAdmin(caller.userId, py.programId);

--- a/src/routes/programYears.ts
+++ b/src/routes/programYears.ts
@@ -69,7 +69,7 @@ router.get('/program-years/:id', async (req, res) => {
   const caller = (req as any).user as { userId: number };
   const py = await prisma.programYear.findUnique({ where: { id: Number(id) } });
   if (!py) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const isMember = await isProgramMember(caller.userId, py.programId);
@@ -86,7 +86,7 @@ router.put('/program-years/:id', async (req, res) => {
   const caller = (req as any).user as { userId: number };
   const py = await prisma.programYear.findUnique({ where: { id: Number(id) } });
   if (!py) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const isAdmin = await isProgramAdmin(caller.userId, py.programId);
@@ -119,7 +119,7 @@ router.delete('/program-years/:id', async (req, res) => {
   const caller = (req as any).user as { userId: number };
   const py = await prisma.programYear.findUnique({ where: { id: Number(id) } });
   if (!py) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const isAdmin = await isProgramAdmin(caller.userId, py.programId);

--- a/src/routes/programs.ts
+++ b/src/routes/programs.ts
@@ -102,7 +102,7 @@ router.get('/programs/:id', async (req, res) => {
   const caller = (req as any).user as { userId: number };
   const program = await prisma.program.findUnique({ where: { id } });
   if (!program) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const member = await isProgramMember(caller.userId, id!);
@@ -120,7 +120,7 @@ router.put('/programs/:id', async (req, res) => {
   const caller = (req as any).user as { userId: number; email: string };
   const program = await prisma.program.findUnique({ where: { id } });
   if (!program) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const isAdmin = await isProgramAdmin(caller.userId, id!);
@@ -147,7 +147,7 @@ router.delete('/programs/:id', async (req, res) => {
   const caller = (req as any).user as { userId: number; email: string };
   const program = await prisma.program.findUnique({ where: { id } });
   if (!program) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const isAdmin = await isProgramAdmin(caller.userId, id!);

--- a/src/routes/staff.ts
+++ b/src/routes/staff.ts
@@ -10,7 +10,7 @@ router.post('/program-years/:id/staff', async (req, res) => {
   const caller = (req as any).user as { userId: number };
   const py = await prisma.programYear.findUnique({ where: { id: Number(id) } });
   if (!py) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const isAdmin = await isProgramAdmin(caller.userId, py.programId);
@@ -53,7 +53,7 @@ router.get('/program-years/:id/staff', async (req, res) => {
   const caller = (req as any).user as { userId: number };
   const py = await prisma.programYear.findUnique({ where: { id: Number(id) } });
   if (!py) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const isMember = await isProgramMember(caller.userId, py.programId);
@@ -70,12 +70,12 @@ router.put('/staff/:id', async (req, res) => {
   const caller = (req as any).user as { userId: number };
   const staff = await prisma.staff.findUnique({ where: { id: Number(id) } });
   if (!staff) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const py = await prisma.programYear.findUnique({ where: { id: staff.programYearId } });
   if (!py) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const isAdmin = await isProgramAdmin(caller.userId, py.programId);
@@ -106,12 +106,12 @@ router.delete('/staff/:id', async (req, res) => {
   const caller = (req as any).user as { userId: number };
   const staff = await prisma.staff.findUnique({ where: { id: Number(id) } });
   if (!staff) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const py = await prisma.programYear.findUnique({ where: { id: staff.programYearId } });
   if (!py) {
-    res.status(404).json({ error: 'Not found' });
+    res.status(204).end();
     return;
   }
   const isAdmin = await isProgramAdmin(caller.userId, py.programId);

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -28,7 +28,7 @@ export async function getUserPrograms(
 
   const user = await prisma.user.findUnique({ where: { email: username } });
   if (!user) {
-    res.status(404).json({ error: 'User not found' });
+    res.status(204).end();
     return;
   }
 


### PR DESCRIPTION
## Summary
- replace 404 errors with 204 No Content across API routes
- update auth helper to send 204 when user is missing
- adjust tests for 204 responses

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68900eae42d8832dadd114d8f64675c7